### PR TITLE
restore nested inputs support

### DIFF
--- a/lib/generators/pu/gem/annotate/templates/lib/tasks/auto_annotate_models.rake
+++ b/lib/generators/pu/gem/annotate/templates/lib/tasks/auto_annotate_models.rake
@@ -44,7 +44,7 @@ task :set_annotation_options do
     "format_bare" => "true",
     "format_rdoc" => "false",
     "format_yard" => "false",
-    "format_markdown" => "true",
+    "format_markdown" => "false",
     "sort" => "false",
     "force" => "false",
     "frozen" => "false",

--- a/lib/plutonium/definition/actions.rb
+++ b/lib/plutonium/definition/actions.rb
@@ -14,8 +14,12 @@ module Plutonium
           end
         end
 
-        def action(name, **)
-          instance_defined_actions[name] = Plutonium::Action::Simple.new(name, **)
+        def action(name, interaction: nil, **)
+          instance_defined_actions[name] = if interaction
+            Plutonium::Action::Interactive::Factory.create(name, interaction:, **)
+          else
+            Plutonium::Action::Simple.new(name, **)
+          end
         end
 
         def defined_actions

--- a/lib/plutonium/definition/base.rb
+++ b/lib/plutonium/definition/base.rb
@@ -29,6 +29,7 @@ module Plutonium
       include Actions
       include Sorting
       include Search
+      include NestedInputs
 
       class IndexPage < Plutonium::UI::Page::Index; end
 

--- a/lib/plutonium/definition/nested_inputs.rb
+++ b/lib/plutonium/definition/nested_inputs.rb
@@ -1,0 +1,19 @@
+module Plutonium
+  module Definition
+    module NestedInputs
+      extend ActiveSupport::Concern
+
+      included do
+        defineable_prop :nested_input
+
+        # def self.nested_input(name, with: nil, **)
+        #   defined_nested_inputs[name] = {}
+        # end
+
+        # def nested_input(name, with: nil, **)
+        #   instance_defined_nested_inputs[name] = {}
+        # end
+      end
+    end
+  end
+end

--- a/lib/plutonium/resource/controller.rb
+++ b/lib/plutonium/resource/controller.rb
@@ -59,7 +59,7 @@ module Plutonium
       # Returns the submitted resource parameters
       # @return [Hash] The submitted resource parameters
       def submitted_resource_params
-        @submitted_resource_params ||= build_form(resource_class.new).extract_input(params)[resource_param_key.to_sym]
+        @submitted_resource_params ||= build_form(resource_class.new).extract_input(params, view_context:)[resource_param_key.to_sym]
       end
 
       # Returns the resource parameters, including scoped and parent parameters

--- a/lib/plutonium/resource/controllers/interactive_actions.rb
+++ b/lib/plutonium/resource/controllers/interactive_actions.rb
@@ -232,7 +232,7 @@ module Plutonium
           @submitted_interaction_params ||= current_interactive_action
             .interaction
             .build_form(nil)
-            .extract_input(params)[:interaction]
+            .extract_input(params, view_context:)[:interaction]
         end
 
         def redirect_url_after_action_on(resource_record_or_resource_class)

--- a/lib/plutonium/resource/controllers/presentable.rb
+++ b/lib/plutonium/resource/controllers/presentable.rb
@@ -5,7 +5,7 @@ module Plutonium
         extend ActiveSupport::Concern
 
         included do
-          helper_method :presentable_attributes, :present_associations?
+          helper_method :presentable_attributes
           helper_method :build_form, :build_detail, :build_collection
         end
 
@@ -30,10 +30,6 @@ module Plutonium
 
         def build_form(record = resource_record)
           current_definition.form_class.new(record, resource_fields: presentable_attributes, resource_definition: current_definition)
-        end
-
-        def present_associations?
-          current_parent.nil?
         end
       end
     end

--- a/lib/plutonium/ui/display/resource.rb
+++ b/lib/plutonium/ui/display/resource.rb
@@ -91,7 +91,7 @@ module Plutonium
         end
 
         def present_associations?
-          current_parent.nil?
+          current_turbo_frame.nil?
         end
       end
     end

--- a/lib/plutonium/ui/form/concerns/renders_nested_resource_fields.rb
+++ b/lib/plutonium/ui/form/concerns/renders_nested_resource_fields.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module UI
+    module Form
+      module Concerns
+        # Handles rendering of nested resource fields in forms
+        # @api private
+        module RendersNestedResourceFields
+          extend ActiveSupport::Concern
+
+          DEFAULT_NESTED_LIMIT = 10
+          NESTED_OPTION_KEYS = [:allow_destroy, :update_only, :macro, :class].freeze
+          SINGULAR_MACROS = %i[belongs_to has_one].freeze
+
+          class NestedInputsDefinition
+            include Plutonium::Definition::DefineableProps
+
+            defineable_props :field, :input
+          end
+
+          # Template object for new nested records
+          class NotPersisted
+            def persisted?
+              false
+            end
+          end
+
+          private
+
+          # Renders a nested resource field with associated inputs
+          # @param [Symbol] name The name of the nested resource field
+          # @raise [ArgumentError] if the nested input definition is missing required configuration
+          def render_nested_resource_field(name)
+            context = NestedFieldContext.new(
+              name: name,
+              definition: build_nested_definition(name),
+              resource_class: resource_class,
+              resource_definition: resource_definition
+            )
+
+            render_nested_field_container(context) do
+              render_nested_field_header(context)
+              render_nested_field_content(context)
+              render_nested_add_button(context)
+            end
+          end
+
+          private
+
+          class NestedFieldContext
+            attr_reader :name, :definition, :options, :permitted_fields
+
+            def initialize(name:, definition:, resource_class:, resource_definition:)
+              @name = name
+              @definition = definition
+              @resource_definition = resource_definition
+              @resource_class = resource_class
+              @options = build_options
+              @permitted_fields = build_permitted_fields
+            end
+
+            def nested_attribute_options
+              @nested_attribute_options ||= @resource_class.all_nested_attributes_options[@name] || {}
+            end
+
+            def nested_input_param
+              @options[:as] || :"#{@name}_attributes"
+            end
+
+            def multiple?
+              @options[:multiple]
+            end
+
+            private
+
+            def build_options
+              options = @resource_definition.defined_nested_inputs[@name][:options].dup || {}
+              merge_nested_options(options)
+              set_nested_limits(options)
+              options
+            end
+
+            def merge_nested_options(options)
+              NESTED_OPTION_KEYS.each do |key|
+                options.fetch(key) { options[key] = nested_attribute_options[key] }
+              end
+            end
+
+            def set_nested_limits(options)
+              options.fetch(:limit) do
+                options[:limit] = if SINGULAR_MACROS.include?(nested_attribute_options[:macro])
+                  1
+                else
+                  nested_attribute_options[:limit] || DEFAULT_NESTED_LIMIT
+                end
+              end
+
+              options.fetch(:multiple) do
+                options[:multiple] = !SINGULAR_MACROS.include?(nested_attribute_options[:macro])
+              end
+            end
+
+            def build_permitted_fields
+              @options[:fields] || @definition.defined_inputs.keys
+            end
+          end
+
+          def build_nested_definition(name)
+            nested_input_definition = resource_definition.defined_nested_inputs[name]
+
+            if nested_input_definition[:options]&.fetch(:using, nil)
+              nested_input_definition[:options][:using]
+            elsif nested_input_definition[:block]
+              build_definition_from_block(nested_input_definition[:block])
+            else
+              raise_missing_nested_definition_error(name)
+            end
+          end
+
+          def build_definition_from_block(block)
+            definition = NestedInputsDefinition.new
+            block.call(definition)
+            definition
+          end
+
+          def render_nested_field_container(context, &)
+            div(
+              class: "col-span-full space-y-2 my-4",
+              data: {
+                controller: "nested-resource-form-fields",
+                nested_resource_form_fields_limit_value: context.options[:limit]
+              },
+              &
+            )
+          end
+
+          def render_nested_field_header(context)
+            div do
+              h2(class: "text-lg font-semibold text-gray-900 dark:text-white") { context.name.to_s.humanize }
+              render_description(context.options[:description]) if context.options[:description]
+            end
+          end
+
+          def render_description(description)
+            p(class: "text-md font-normal text-gray-500 dark:text-gray-400") { description }
+          end
+
+          def render_nested_field_content(context)
+            if context.multiple?
+              render_multiple_nested_fields(context)
+            else
+              render_single_nested_field(context)
+            end
+
+            div(data_nested_resource_form_fields_target: :target, hidden: true)
+          end
+
+          def render_multiple_nested_fields(context)
+            render_template_for_nested_fields(context, collection: {NEW_RECORD: NotPersisted.new})
+            render_existing_nested_fields(context)
+          end
+
+          def render_single_nested_field(context)
+            render_template_for_nested_fields(context, object: NotPersisted.new)
+            render_existing_nested_fields(context, single: true)
+          end
+
+          def render_template_for_nested_fields(context, field_options)
+            template_tag data_nested_resource_form_fields_target: "template" do
+              nesting_method = field_options[:collection] ? :nest_many : :nest_one
+              send(nesting_method, context.name, as: context.nested_input_param, template: true, **field_options) do |nested|
+                render_fieldset(nested, context)
+              end
+            end
+          end
+
+          def render_existing_nested_fields(context, single: false)
+            nesting_method = single ? :nest_one : :nest_many
+            send(nesting_method, context.name, as: context.nested_input_param) do |nested|
+              render_fieldset(nested, context)
+            end
+          end
+
+          def render_fieldset(nested, context)
+            fieldset(
+              data_new_record: !nested.object&.persisted?,
+              class: "nested-resource-form-fields border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-4 relative"
+            ) do
+              render_fieldset_content(nested, context)
+              render_delete_button(nested, context.options)
+            end
+          end
+
+          def render_fieldset_content(nested, context)
+            div(class: "grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-4 gap-4 grid-flow-row-dense") do
+              render_hidden_fields(nested, context)
+              render_input_fields(nested, context)
+            end
+          end
+
+          def render_hidden_fields(nested, context)
+            if !context.options[:update_only] && context.options[:class]&.respond_to?(:primary_key)
+              render nested.field(context.options[:class].primary_key).hidden_tag
+            end
+            render nested.field(:_destroy).hidden_tag if context.options[:allow_destroy]
+          end
+
+          def render_input_fields(nested, context)
+            context.permitted_fields.each do |input|
+              render_simple_resource_field(input, context.definition, nested)
+            end
+          end
+
+          def render_delete_button(nested, options)
+            return unless !nested.object&.persisted? || options[:allow_destroy]
+
+            render_delete_button_content
+          end
+
+          def render_delete_button_content
+            div(class: "flex items-center justify-end") do
+              label(class: "inline-flex items-center text-md font-medium text-red-900 cursor-pointer") do
+                plain "Delete"
+                render_delete_checkbox
+              end
+            end
+          end
+
+          def render_delete_checkbox
+            input(
+              type: :checkbox,
+              class: "w-4 h-4 ms-2 text-red-600 bg-red-100 border-red-300 rounded focus:ring-red-500 dark:focus:ring-red-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 cursor-pointer",
+              data_action: "nested-resource-form-fields#remove"
+            )
+          end
+
+          def render_nested_add_button(context)
+            div do
+              button(
+                type: :button,
+                class: "inline-block",
+                data: {
+                  action: "nested-resource-form-fields#add",
+                  nested_resource_form_fields_target: "addButton"
+                }
+              ) do
+                render_add_button_content(context.name)
+              end
+            end
+          end
+
+          def render_add_button_content(name)
+            span(class: "bg-secondary-700 text-white hover:bg-secondary-800 focus:ring-secondary-300 dark:bg-secondary-600 dark:hover:bg-secondary-700 dark:focus:ring-secondary-800 flex items-center justify-center px-4 py-1.5 text-sm font-medium rounded-lg focus:outline-none focus:ring-4") do
+              render Phlex::TablerIcons::Plus.new(class: "w-4 h-4 mr-1")
+              span { "Add #{name.to_s.singularize.humanize}" }
+            end
+          end
+
+          def raise_missing_nested_definition_error(name)
+            raise ArgumentError, %(
+              `nested_input :#{name}` is missing a definition
+
+              you can either pass in a block:
+              ```ruby
+              nested_input :#{name} do |definition|
+                input :city
+                input :country
+              end
+              ```
+
+              or pass in options:
+              ```ruby
+              nested_input :#{name}, using: #{name.to_s.classify}Definition, fields: %i[city country]
+              ```
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/ui/form/theme.rb
+++ b/lib/plutonium/ui/form/theme.rb
@@ -7,7 +7,7 @@ module Plutonium
         def self.theme
           super.merge({
             base: "relative bg-white dark:bg-gray-800 shadow-md sm:rounded-lg my-3 p-6 space-y-6",
-            fields_wrapper: "grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-4 gap-6 grid-flow-row-dense",
+            fields_wrapper: "grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-4 gap-4 grid-flow-row-dense",
             actions_wrapper: "flex justify-end space-x-2",
             wrapper: nil,
             inner_wrapper: "w-full",

--- a/src/js/controllers/nested_resource_form_fields_controller.js
+++ b/src/js/controllers/nested_resource_form_fields_controller.js
@@ -33,11 +33,11 @@ export default class extends Controller {
     e.preventDefault()
 
     const wrapper = e.target.closest(this.wrapperSelectorValue)
-
-    if (wrapper.dataset.newRecord === "true") {
+    if (wrapper.dataset.newRecord !== undefined) {
       wrapper.remove()
     } else {
       wrapper.style.display = "none"
+      wrapper.classList.remove(...wrapper.classList)
 
       const input = wrapper.querySelector("input[name*='_destroy']")
       input.value = "1"


### PR DESCRIPTION
```ruby
class Blogging::CommentDefinition < Blogging::ResourceDefinition
  # Define nested inputs inline
  nested_input :user do |f|
    f.input :email
    f.input :status
  end

  # Reuse an existing definition and specify the fields to expose
  nested_input :user, using: UserDefinition, fields: %i[email status]
end
```

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3cdc3896-89e3-425c-b179-76e866568c6b">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/137fee82-dccc-45c6-90cd-b47e83ad445b">
