### PR TITLE
refresh dyna host turbo tag when we refresh the page

### DIFF
--- a/lib/plutonium/ui/dyna_frame/host.rb
+++ b/lib/plutonium/ui/dyna_frame/host.rb
@@ -12,7 +12,7 @@ module Plutonium
         end
 
         def view_template(&)
-          turbo_frame_tag(@id, src: @src, loading: @loading, **@attributes, class: 'dyna', &)
+          turbo_frame_tag(@id, src: @src, loading: @loading, **@attributes, class: "dyna", refresh: "morph", &)
         end
       end
     end


### PR DESCRIPTION
ensures that the turbo frame for dyna hosted content e.g. the association panel in https://github.com/radioactive-labs/plutonium-core/issues/8 reloads on page refresh.