### PR TITLE
allow customization of application name in the generated title

### DIFF
--- a/lib/plutonium/core/controller.rb
+++ b/lib/plutonium/core/controller.rb
@@ -12,11 +12,12 @@ module Plutonium
         before_action do
           next unless defined?(ActiveStorage)
 
-          ActiveStorage::Current.url_options = {protocol: request.protocol, host: request.host, port: request.port}
+          ActiveStorage::Current.url_options = { protocol: request.protocol, host: request.host, port: request.port }
         end
 
         helper Plutonium::Helpers
-        helper_method :make_page_title, :resource_url_for, :resource_url_args_for, :root_path
+        helper_method :make_page_title, :resource_url_for,
+          :resource_url_args_for, :root_path, :app_name
 
         append_view_path File.expand_path("app/views", Plutonium.root)
         layout -> { turbo_frame_request? ? false : "resource" }
@@ -29,8 +30,24 @@ module Plutonium
         @page_title = page_title
       end
 
-      def make_page_title(title, app_name: helpers.application_name)
+      def make_page_title(title)
         [title.presence, app_name].compact.join(" | ")
+      end
+
+      # Returns the name of the application as defined in the configuration
+      #
+      # This value can be overridden to provide a custom name for the application
+      # which will then be used to set the page title
+      #
+      # For example, if the application name is "Acme", the page title
+      # will be set to "Login | Acme"
+      #
+      # example:
+      #   def app_name = "Acme"
+      #
+      # @return [String] the name of the application
+      def app_name
+        helpers.application_name
       end
 
       #
@@ -61,7 +78,7 @@ module Plutonium
       # @return [Hash] args to pass to `url_for`
       #
       def resource_url_args_for(*args, action: nil, parent: nil, **kwargs)
-        url_args = {**kwargs, action: action}.compact
+        url_args = { **kwargs, action: action }.compact
 
         controller_chain = [current_package&.to_s].compact
         [*args].compact.each_with_index do |element, index|

--- a/lib/plutonium/core/controller.rb
+++ b/lib/plutonium/core/controller.rb
@@ -29,8 +29,8 @@ module Plutonium
         @page_title = page_title
       end
 
-      def make_page_title(title)
-        [title.presence, helpers.application_name].compact.join(" | ")
+      def make_page_title(title, app_name: helpers.application_name)
+        [title.presence, app_name].compact.join(" | ")
       end
 
       #

--- a/lib/plutonium/core/controller.rb
+++ b/lib/plutonium/core/controller.rb
@@ -12,7 +12,7 @@ module Plutonium
         before_action do
           next unless defined?(ActiveStorage)
 
-          ActiveStorage::Current.url_options = { protocol: request.protocol, host: request.host, port: request.port }
+          ActiveStorage::Current.url_options = {protocol: request.protocol, host: request.host, port: request.port}
         end
 
         helper Plutonium::Helpers
@@ -34,18 +34,6 @@ module Plutonium
         [title.presence, app_name].compact.join(" | ")
       end
 
-      # Returns the name of the application as defined in the configuration
-      #
-      # This value can be overridden to provide a custom name for the application
-      # which will then be used to set the page title
-      #
-      # For example, if the application name is "Acme", the page title
-      # will be set to "Login | Acme"
-      #
-      # example:
-      #   def app_name = "Acme"
-      #
-      # @return [String] the name of the application
       def app_name
         helpers.application_name
       end
@@ -78,7 +66,7 @@ module Plutonium
       # @return [Hash] args to pass to `url_for`
       #
       def resource_url_args_for(*args, action: nil, parent: nil, **kwargs)
-        url_args = { **kwargs, action: action }.compact
+        url_args = {**kwargs, action: action}.compact
 
         controller_chain = [current_package&.to_s].compact
         [*args].compact.each_with_index do |element, index|

--- a/lib/plutonium/ui/form/interaction.rb
+++ b/lib/plutonium/ui/form/interaction.rb
@@ -25,7 +25,7 @@ module Plutonium
         end
 
         def submit_button(*, **)
-          super(*, **) do
+          super do
             object.label
           end
         end


### PR DESCRIPTION
This pull request includes changes to improve the flexibility and functionality of methods in the `lib/plutonium` directory. The most important changes include modifying the `make_page_title` method to accept an optional `app_name` parameter and simplifying the `submit_button` method by removing redundant parameters.

Improvements to method parameters:

* [`lib/plutonium/core/controller.rb`](diffhunk://#diff-77cf3e660908a357e64a389082b589dc6fcf633afe761a96ea0518fa7be7bdecL32-R33): Modified the `make_page_title` method to accept an optional `app_name` parameter, allowing more flexibility in setting the page title.

Code simplification:

* [`lib/plutonium/ui/form/interaction.rb`](diffhunk://#diff-2a85cf9b7356a231e0ec62f169e000766fdb7d4ca78533a82cb7c5e0e08bcd3cL28-R28): Simplified the `submit_button` method by removing redundant parameters, making the code cleaner and easier to maintain.