### PR TITLE
add configuration to control breadcrumb display

### DIFF
--- a/lib/plutonium/definition/base.rb
+++ b/lib/plutonium/definition/base.rb
@@ -26,6 +26,7 @@ module Plutonium
     class Base
       include DefineableProps
       include ConfigAttr
+      include InheritableConfigAttr
       include Actions
       include Sorting
       include Search
@@ -63,6 +64,14 @@ module Plutonium
         :show_page_title, :show_page_description,
         :new_page_title, :new_page_description,
         :edit_page_title, :edit_page_description
+
+      # breadcrumbs
+      inheritable_config_attr :breadcrumbs,
+        :index_page_breadcrumbs, :new_page_breadcrumbs,
+        :edit_page_breadcrumbs, :show_page_breadcrumbs,
+        :interactive_action_page_breadcrumbs
+      # global default
+      breadcrumbs true
 
       def initialize
         super

--- a/lib/plutonium/definition/inheritable_config_attr.rb
+++ b/lib/plutonium/definition/inheritable_config_attr.rb
@@ -1,0 +1,33 @@
+module Plutonium
+  module Definition
+    module InheritableConfigAttr
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def inheritable_config_attr(*names)
+          names.each do |name|
+            # Create the underlying class_attribute
+            attr_name = :"#{name}_config"
+            class_attribute attr_name, instance_reader: true, instance_accessor: false, default: nil
+
+            # Define class-level method that acts as both getter/setter
+            define_singleton_method(name) do |value = :__not_set__|
+              if value == :__not_set__
+                # Getter behavior
+                public_send(:"#{attr_name}")
+              else
+                # Setter behavior
+                public_send(:"#{attr_name}=", value)
+              end
+            end
+
+            # Instance-level method
+            define_method(name) do
+              self.class.send(name)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/ui/page/base.rb
+++ b/lib/plutonium/ui/page/base.rb
@@ -43,7 +43,15 @@ module Plutonium
         end
 
         def render_breadcrumbs
+          return unless render_breadcrumbs?
+
           Breadcrumbs()
+        end
+
+        def render_breadcrumbs?
+          # Check specific page setting first, fall back to global setting
+          page_specific_setting = current_definition.send(:"#{page_type}_breadcrumbs")
+          page_specific_setting.nil? ? current_definition.breadcrumbs : page_specific_setting
         end
 
         def render_page_header
@@ -106,6 +114,8 @@ module Plutonium
 
         def render_after_footer
         end
+
+        def page_type = raise NotImplementedError, "#{self.class}#page_type"
       end
     end
   end

--- a/lib/plutonium/ui/page/edit.rb
+++ b/lib/plutonium/ui/page/edit.rb
@@ -17,6 +17,8 @@ module Plutonium
         def render_default_content
           render "resource_form"
         end
+
+        def page_type = :edit_page
       end
     end
   end

--- a/lib/plutonium/ui/page/index.rb
+++ b/lib/plutonium/ui/page/index.rb
@@ -21,6 +21,8 @@ module Plutonium
         def render_default_content
           render "resource_table"
         end
+
+        def page_type = :index_page
       end
     end
   end

--- a/lib/plutonium/ui/page/interactive_action.rb
+++ b/lib/plutonium/ui/page/interactive_action.rb
@@ -17,6 +17,8 @@ module Plutonium
         def render_default_content
           render "interactive_action_form"
         end
+
+        def page_type = :interactive_action_page
       end
     end
   end

--- a/lib/plutonium/ui/page/new.rb
+++ b/lib/plutonium/ui/page/new.rb
@@ -17,6 +17,8 @@ module Plutonium
         def render_default_content
           render "resource_form"
         end
+
+        def page_type = :new_page
       end
     end
   end

--- a/lib/plutonium/ui/page/show.rb
+++ b/lib/plutonium/ui/page/show.rb
@@ -21,6 +21,8 @@ module Plutonium
         def render_default_content
           render "resource_details"
         end
+
+        def page_type = :show_page
       end
     end
   end


### PR DESCRIPTION
# Breadcrumbs Configuration

Plutonium allows you to control the visibility of breadcrumbs both globally and per page type. The configuration is inheritable, allowing you to set defaults for groups of resources while maintaining the ability to override specific pages when needed.

## Usage

```ruby
class AdminResourceDefinition < Plutonium::Definition::Base
  # Disable breadcrumbs globally for this resource and its subclasses
  breadcrumbs false
end

class UserDefinition < Plutonium::Definition::Base
  # Disable breadcrumbs only for specific pages
  index_page_breadcrumbs false
  new_page_breadcrumbs false
  
  # Other pages will inherit from global setting (default: true)
end

class ProductDefinition < AdminResourceDefinition
  # Override parent's setting for specific pages
  show_page_breadcrumbs true
  edit_page_breadcrumbs true
end
```

## Configuration Options

| Setting | Description | Default |
|---------|-------------|---------|
| `breadcrumbs` | Global setting for all pages | `true` |
| `index_page_breadcrumbs` | Control breadcrumbs on index page | inherits from `breadcrumbs` |
| `new_page_breadcrumbs` | Control breadcrumbs on new record page | inherits from `breadcrumbs` |
| `edit_page_breadcrumbs` | Control breadcrumbs on edit page | inherits from `breadcrumbs` |
| `show_page_breadcrumbs` | Control breadcrumbs on show page | inherits from `breadcrumbs` |
| `interactive_action_page_breadcrumbs` | Control breadcrumbs on interactive action pages | inherits from `breadcrumbs` |

## Inheritance Rules

1. Page-specific settings take precedence over the global setting
2. If a page-specific setting is not defined, it falls back to the global `breadcrumbs` setting
3. Both global and page-specific settings are inherited by subclasses
4. Subclasses can override any setting without affecting the parent class

## Examples

### Basic Configuration
```ruby
class ResourceDefinition < Plutonium::Definition::Base
  # Set global default
  breadcrumbs false
end
```

### Mixed Configuration
```ruby
class ComplexResourceDefinition < Plutonium::Definition::Base
  # Disable globally
  breadcrumbs false
  
  # Enable for specific pages
  show_page_breadcrumbs true
  edit_page_breadcrumbs true
end
```

### Inherited Configuration
```ruby
# Base admin configuration
class AdminResourceDefinition < Plutonium::Definition::Base
  breadcrumbs false
end

# Inherits no breadcrumbs from AdminResourceDefinition
class UserAdminDefinition < AdminResourceDefinition
  # Override just the show page
  show_page_breadcrumbs true
end
```