### PR TITLE
fix: Fix Tailwind CSS v4 upgrade issue for existing projects

### DIFF
--- a/lib/generators/pu/core/assets/assets_generator.rb
+++ b/lib/generators/pu/core/assets/assets_generator.rb
@@ -49,6 +49,11 @@ module Pu
           registerControllers(application)
         EOT
 
+        # For older versions tailwindcss, specifically v3
+        gsub_file "app/assets/stylesheets/application.tailwind.css", %r{@tailwind\s+base;\s*@tailwind\s+components;\s*@tailwind\s+utilities;\s*} do
+          "@import \"tailwindcss\";\n@config '../../../tailwind.config.js';\n"
+        end
+
         insert_into_file "app/assets/stylesheets/application.tailwind.css", <<~EOT, after: /@import "tailwindcss";\n/
           @config '../../../tailwind.config.js';
         EOT


### PR DESCRIPTION
This PR fixes the import substitution lines for the asset generator when run in an existing project. It correctly handles the removal of the old (v3) tailwindcss config found in the `application.tailwind.css` file with the config used by new projects.

The current tailwind v4 works well with new projects, but not very well with existing projects. Though it succeeds in updating the `package.json` and `postcss.config.js` files, it fails to correctly update the `application.tailwind.css` asset file.

This causes the error below (left side) because the tailwind config was correctly updated (right side).
![image](https://github.com/user-attachments/assets/aa731648-c199-4ed9-859c-5087008fa0f4)

After the fix is applied, it runs successfully, updates the config file and the project can be run without issues.
![image](https://github.com/user-attachments/assets/f0823876-997b-41cd-afac-f044ee2821af)
