### PR TITLE
Preserve Whitespace in Hints to Allow Some Formatting

### DIFF
--- a/lib/plutonium/ui/form/theme.rb
+++ b/lib/plutonium/ui/form/theme.rb
@@ -37,7 +37,7 @@ module Plutonium
             # file
             # file: "w-full border rounded-md shadow-sm font-medium text-sm dark:bg-gray-700 focus:outline-none",
             # hint themes
-            hint: "mt-2 text-sm text-gray-500 dark:text-gray-200",
+            hint: "mt-2 text-sm text-gray-500 dark:text-gray-200 whitespace-pre",
             # error themes
             error: "mt-2 text-sm text-red-600 dark:text-red-500",
             # button themes


### PR DESCRIPTION
Before this PR, here's what hints looked like

![image](https://github.com/user-attachments/assets/ae17780e-3639-4542-a083-2630859885d9)

After the update

![image](https://github.com/user-attachments/assets/cd619570-24bf-412e-9e82-554cc4b6cc6c)

This is the code used

![image](https://github.com/user-attachments/assets/e7a58c48-b282-4c10-b5bb-fbf2504d078e)
