### PR TITLE
Ensure attachment responds to URL before rendering

### DIFF
--- a/lib/plutonium/ui/form/components/uppy.rb
+++ b/lib/plutonium/ui/form/components/uppy.rb
@@ -53,7 +53,7 @@ module Plutonium
 
           def render_existing_attachments
             Array(field.value).each do |attachment|
-              next unless attachment&.url.present?
+              next unless attachment.respond_to?(:url) && attachment&.url.present?
 
               render_attachment_preview(attachment)
             end


### PR DESCRIPTION
Check if the attachment responds to the URL method before attempting to render it, preventing potential errors.