### PR TITLE
Add Default Role Management for Entity Generator

### DIFF
--- a/docs/modules/generator.md
+++ b/docs/modules/generator.md
@@ -238,7 +238,7 @@ end
 
 # app/models/organization_customer.rb
 class OrganizationCustomer < ::ResourceRecord
-  enum :role, owner: 1, member: 2
+  enum :role, member: 0, owner: 1
 
   belongs_to :organization
   belongs_to :customer

--- a/docs/modules/generator.md
+++ b/docs/modules/generator.md
@@ -238,10 +238,10 @@ end
 
 # app/models/organization_customer.rb
 class OrganizationCustomer < ::ResourceRecord
+  enum :role, owner: 1, member: 2
 
   belongs_to :organization
   belongs_to :customer
-  enum role: { member: 0, admin: 1 }
 end
 ```
 

--- a/lib/generators/pu/res/entity/entity_generator.rb
+++ b/lib/generators/pu/res/entity/entity_generator.rb
@@ -127,7 +127,7 @@ module Pu
         migration_file = Dir[File.join(migration_dir, "*_create_#{normalized_entity_membership_name.pluralize}.rb")].first
 
         modify_file_if_exists(migration_file) do |file|
-          gsub_file file, /t\.integer :role, null: false/, "t.integer :role, null: false, default: 2  # Member by default"
+          gsub_file file, /t\.integer :role, null: false/, "t.integer :role, null: false, default: 0  # Member by default"
         end
       end
 
@@ -135,7 +135,7 @@ module Pu
         model_file = File.join("app", "models", "#{normalized_entity_membership_name}.rb")
 
         modify_file_if_exists(model_file) do |file|
-          enum_definition = "\nenum :role, owner: 1, member: 2"
+          enum_definition = "\nenum :role, member: 0, owner: 1"
           insert_into_file file, indent(enum_definition, 2), before: /^\s*# add model configurations above\./
         end
       end

--- a/lib/generators/pu/rodauth/customer_generator.rb
+++ b/lib/generators/pu/rodauth/customer_generator.rb
@@ -54,7 +54,6 @@ module Pu
             has_many :#{normalized_entity_membership_name.pluralize}
               has_many :#{normalized_name.pluralize}, through: :#{normalized_entity_membership_name.pluralize}
           RUBY
-          success "Added relationship to #{normalized_entity_name} model"
         end
 
         customer_model_path = File.join("app", "models", "#{normalized_name}.rb")
@@ -63,7 +62,6 @@ module Pu
             has_many :#{normalized_entity_membership_name.pluralize}
               has_many :#{normalized_entity_name.pluralize}, through: :#{normalized_entity_membership_name.pluralize}
           RUBY
-          success "Added relationship to #{normalized_name} model"
         end
       end
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of role-based logic and database migrations in the for the entity generator. Key changes include:
- the addition of a default value for the `role` column in the migration file for the entity member model
- updates to the `enum` definition for roles
  - We have `owner` and `member` roles.
- general code refactors such as removing the extra debug messages
-  documentation update to reflect the change