### PR TITLE
Fix: Check SQLite3 adapter before defining jsonb alias

### DIFF
--- a/config/initializers/sqlite_alias.rb
+++ b/config/initializers/sqlite_alias.rb
@@ -1,4 +1,6 @@
 # Alias json to jsonb in SQLite migrations
+return unless defined?(ActiveRecord::ConnectionAdapters::SQLite3)
+
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition.class_eval do
     def jsonb(*args, **options)

--- a/config/initializers/sqlite_alias.rb
+++ b/config/initializers/sqlite_alias.rb
@@ -2,8 +2,6 @@
 return unless defined?(ActiveRecord::ConnectionAdapters::SQLite3)
 
 ActiveSupport.on_load(:active_record) do
-  next unless ActiveRecord::Base.connection.adapter_name.downcase.include?("sqlite")
-
   ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition.class_eval do
     def jsonb(*args, **options)
       json(*args, **options)

--- a/config/initializers/sqlite_alias.rb
+++ b/config/initializers/sqlite_alias.rb
@@ -2,6 +2,8 @@
 return unless defined?(ActiveRecord::ConnectionAdapters::SQLite3)
 
 ActiveSupport.on_load(:active_record) do
+  next unless ActiveRecord::Base.connection.adapter_name.downcase.include?("sqlite")
+
   ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition.class_eval do
     def jsonb(*args, **options)
       json(*args, **options)

--- a/lib/plutonium/core/controller.rb
+++ b/lib/plutonium/core/controller.rb
@@ -77,15 +77,14 @@ module Plutonium
             model_class = element.class
             if model_class.respond_to?(:base_class) && model_class != model_class.base_class
               # Check if the STI model is registered, if not use base class
-              route_configs = current_engine.routes.resource_route_config_for(model_class.to_s.pluralize.underscore)
-              model_class = model_class.base_class if route_configs.nil? || route_configs.empty?
+              route_configs = current_engine.routes.resource_route_config_for(model_class.model_name.plural)
+              model_class = model_class.base_class if route_configs.empty?
             end
 
             controller_chain << model_class.to_s.pluralize
             if index == args.length - 1
-              resource_route_configs = current_engine.routes.resource_route_config_for(model_class.to_s.pluralize.underscore)
-              resource_route_config = resource_route_configs&.first
-              url_args[:id] = element.to_param unless resource_route_config && resource_route_config[:route_type] == :resource
+              resource_route_config = current_engine.routes.resource_route_config_for(model_class.model_name.plural)[0]
+              url_args[:id] = element.to_param unless resource_route_config[:route_type] == :resource
               url_args[:action] ||= :show
             else
               url_args[model_class.to_s.underscore.singularize.to_sym] = element.to_param

--- a/lib/plutonium/definition/actions.rb
+++ b/lib/plutonium/definition/actions.rb
@@ -47,7 +47,7 @@ module Plutonium
         action(:destroy, route_options: {method: :delete},
           record_action: true, collection_record_action: true, category: :danger,
           icon: Phlex::TablerIcons::Trash, position: 100,
-          confirmation: "Are you sure?", turbo_frame: "_top", return_to: "")
+          confirmation: "Are you sure?", turbo_frame: "_top")
 
         # Example of dynamic route options using custom url_resolver:
         #

--- a/lib/plutonium/version.rb
+++ b/lib/plutonium/version.rb
@@ -1,5 +1,5 @@
 module Plutonium
-  VERSION = "0.26.7"
+  VERSION = "0.26.8"
   NEXT_MAJOR_VERSION = VERSION.split(".").tap { |v|
     v[1] = v[1].to_i + 1
     v[2] = 0


### PR DESCRIPTION
This pull request adds a check to confirm the presence of the SQLite3 adapter before defining the `jsonb` alias, preventing potential errors when the adapter is unavailable.