### PR TITLE
Add check for SQLite3 adapter before monkey-patching JSON alias

### DIFF
--- a/config/initializers/sqlite_alias.rb
+++ b/config/initializers/sqlite_alias.rb
@@ -1,7 +1,8 @@
 # Alias json to jsonb in SQLite migrations
-ActiveSupport.on_load(:active_record) do
-  next unless ActiveRecord::Base.connection.adapter_name.downcase.include?("sqlite")
 
+return unless defined?(ActiveRecord::ConnectionAdapters::SQLite3)
+
+ActiveSupport.on_load(:active_record) do
   ActiveRecord::ConnectionAdapters::SQLite3::TableDefinition.class_eval do
     def jsonb(*args, **options)
       json(*args, **options)


### PR DESCRIPTION
This pull request adds a check to confirm the presence of the SQLite3 adapter before defining the jsonb alias, preventing potential errors when the adapter is unavailable.