### PR TITLE
fix(auth): dynamically detect database adapter for Rodauth

### DIFF
--- a/lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt
+++ b/lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt
@@ -17,11 +17,8 @@ class RodauthPlugin < Rodauth::Rails::Auth
     # ==> General
 
     # Initialize Sequel and have it reuse Active Record's database connection.
-<% if RUBY_ENGINE == "jruby" -%>
-    db Sequel.connect("jdbc:<%= sequel_adapter %>://", extensions: :activerecord_connection, keep_reference: false)
-<% else -%>
-    db Sequel.<%= sequel_adapter %>(extensions: :activerecord_connection, keep_reference: false)
-<% end -%>
+    # The adapter is detected dynamically at runtime to support database changes.
+    db Plutonium::Auth::SequelAdapter.db
 
     # Change prefix of table and foreign key column names from default "account"
     # accounts_table :users

--- a/lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt
+++ b/lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt
@@ -1,4 +1,5 @@
 require "sequel/core"
+require "plutonium/auth/sequel_adapter"
 
 class RodauthPlugin < Rodauth::Rails::Auth
   attr_accessor :url_options

--- a/lib/plutonium/auth/sequel_adapter.rb
+++ b/lib/plutonium/auth/sequel_adapter.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "sequel/core"
+
+module Plutonium
+  module Auth
+    # Provides runtime detection of the database adapter for Sequel configuration.
+    # This module dynamically detects the ActiveRecord adapter and returns the
+    # corresponding Sequel adapter, allowing users to change their database
+    # without needing to regenerate rodauth files.
+    module SequelAdapter
+      SEQUEL_ADAPTERS = {
+        "postgresql" => RUBY_ENGINE == "jruby" ? "postgresql" : "postgres",
+        "mysql2" => RUBY_ENGINE == "jruby" ? "mysql" : "mysql2",
+        "sqlite3" => "sqlite",
+        "oracle_enhanced" => "oracle",
+        "sqlserver" => RUBY_ENGINE == "jruby" ? "mssql" : "tinytds"
+      }.freeze
+
+      class << self
+        # Returns a Sequel database connection that reuses ActiveRecord's connection.
+        # Automatically detects the correct adapter based on the current ActiveRecord config.
+        #
+        # @return [Sequel::Database] configured Sequel database connection
+        def db
+          if RUBY_ENGINE == "jruby"
+            Sequel.connect("jdbc:#{sequel_adapter}://", extensions: :activerecord_connection, keep_reference: false)
+          else
+            Sequel.public_send(sequel_adapter, extensions: :activerecord_connection, keep_reference: false)
+          end
+        end
+
+        # Returns the Sequel adapter name based on the current ActiveRecord adapter.
+        #
+        # @return [String] the Sequel adapter name
+        def sequel_adapter
+          SEQUEL_ADAPTERS[activerecord_adapter] || activerecord_adapter
+        end
+
+        private
+
+        # Returns the current ActiveRecord adapter name.
+        #
+        # @return [String] the ActiveRecord adapter name
+        def activerecord_adapter
+          if ActiveRecord::Base.respond_to?(:connection_db_config)
+            ActiveRecord::Base.connection_db_config.adapter
+          else
+            ActiveRecord::Base.connection_config.fetch(:adapter)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/auth/sequel_adapter.rb
+++ b/lib/plutonium/auth/sequel_adapter.rb
@@ -9,6 +9,8 @@ module Plutonium
     # corresponding Sequel adapter, allowing users to change their database
     # without needing to regenerate rodauth files.
     module SequelAdapter
+      # Maps ActiveRecord adapter names to their corresponding Sequel adapter names.
+      # JRuby uses JDBC adapters which have different naming conventions.
       SEQUEL_ADAPTERS = {
         "postgresql" => RUBY_ENGINE == "jruby" ? "postgresql" : "postgres",
         "mysql2" => RUBY_ENGINE == "jruby" ? "mysql" : "mysql2",
@@ -22,15 +24,26 @@ module Plutonium
         # Automatically detects the correct adapter based on the current ActiveRecord config.
         #
         # @return [Sequel::Database] configured Sequel database connection
+        # @raise [RuntimeError] if the Sequel adapter initialization fails
         def db
-          if RUBY_ENGINE == "jruby"
-            Sequel.connect("jdbc:#{sequel_adapter}://", extensions: :activerecord_connection, keep_reference: false)
-          else
-            Sequel.public_send(sequel_adapter, extensions: :activerecord_connection, keep_reference: false)
+          adapter = sequel_adapter
+          begin
+            if RUBY_ENGINE == "jruby"
+              Sequel.connect("jdbc:#{adapter}://", extensions: :activerecord_connection, keep_reference: false)
+            else
+              Sequel.public_send(adapter, extensions: :activerecord_connection, keep_reference: false)
+            end
+          rescue => e
+            raise "Failed to initialize Sequel with adapter '#{adapter}'. " \
+                  "Please ensure your database configuration is correct and the required " \
+                  "database gems are installed. Original error: #{e.message}"
           end
         end
 
         # Returns the Sequel adapter name based on the current ActiveRecord adapter.
+        # If the ActiveRecord adapter is not in the SEQUEL_ADAPTERS mapping, the
+        # ActiveRecord adapter name is returned as-is, which may work for adapters
+        # where the names match between ActiveRecord and Sequel.
         #
         # @return [String] the Sequel adapter name
         def sequel_adapter
@@ -42,12 +55,20 @@ module Plutonium
         # Returns the current ActiveRecord adapter name.
         #
         # @return [String] the ActiveRecord adapter name
+        # @raise [RuntimeError] if the ActiveRecord adapter cannot be determined
         def activerecord_adapter
-          if ActiveRecord::Base.respond_to?(:connection_db_config)
-            ActiveRecord::Base.connection_db_config.adapter
+          adapter = if ActiveRecord::Base.respond_to?(:connection_db_config)
+            ActiveRecord::Base.connection_db_config&.adapter
           else
-            ActiveRecord::Base.connection_config.fetch(:adapter)
+            ActiveRecord::Base.connection_config&.fetch(:adapter, nil)
           end
+
+          unless adapter
+            raise "Unable to determine the ActiveRecord database adapter. " \
+                  "Please ensure ActiveRecord is properly configured with a database connection."
+          end
+
+          adapter
         end
       end
     end

--- a/lib/plutonium/auth/sequel_adapter.rb
+++ b/lib/plutonium/auth/sequel_adapter.rb
@@ -12,11 +12,11 @@ module Plutonium
       # Maps ActiveRecord adapter names to their corresponding Sequel adapter names.
       # JRuby uses JDBC adapters which have different naming conventions.
       SEQUEL_ADAPTERS = {
-        "postgresql" => RUBY_ENGINE == "jruby" ? "postgresql" : "postgres",
-        "mysql2" => RUBY_ENGINE == "jruby" ? "mysql" : "mysql2",
+        "postgresql" => (RUBY_ENGINE == "jruby") ? "postgresql" : "postgres",
+        "mysql2" => (RUBY_ENGINE == "jruby") ? "mysql" : "mysql2",
         "sqlite3" => "sqlite",
         "oracle_enhanced" => "oracle",
-        "sqlserver" => RUBY_ENGINE == "jruby" ? "mssql" : "tinytds"
+        "sqlserver" => (RUBY_ENGINE == "jruby") ? "mssql" : "tinytds"
       }.freeze
 
       class << self

--- a/test/plutonium/auth/sequel_adapter_test.rb
+++ b/test/plutonium/auth/sequel_adapter_test.rb
@@ -18,12 +18,12 @@ module Plutonium
       end
 
       def test_sequel_adapters_contains_postgresql_mapping
-        expected = RUBY_ENGINE == "jruby" ? "postgresql" : "postgres"
+        expected = (RUBY_ENGINE == "jruby") ? "postgresql" : "postgres"
         assert_equal expected, SequelAdapter::SEQUEL_ADAPTERS["postgresql"]
       end
 
       def test_sequel_adapters_contains_mysql2_mapping
-        expected = RUBY_ENGINE == "jruby" ? "mysql" : "mysql2"
+        expected = (RUBY_ENGINE == "jruby") ? "mysql" : "mysql2"
         assert_equal expected, SequelAdapter::SEQUEL_ADAPTERS["mysql2"]
       end
 
@@ -36,7 +36,7 @@ module Plutonium
       end
 
       def test_sequel_adapters_contains_sqlserver_mapping
-        expected = RUBY_ENGINE == "jruby" ? "mssql" : "tinytds"
+        expected = (RUBY_ENGINE == "jruby") ? "mssql" : "tinytds"
         assert_equal expected, SequelAdapter::SEQUEL_ADAPTERS["sqlserver"]
       end
 

--- a/test/plutonium/auth/sequel_adapter_test.rb
+++ b/test/plutonium/auth/sequel_adapter_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Plutonium
+  module Auth
+    class SequelAdapterTest < Minitest::Test
+      def setup
+        @original_adapter = nil
+        if ActiveRecord::Base.respond_to?(:connection_db_config)
+          @original_adapter = ActiveRecord::Base.connection_db_config.adapter
+        end
+      end
+
+      # Tests for SEQUEL_ADAPTERS constant
+      def test_sequel_adapters_constant_is_frozen
+        assert SequelAdapter::SEQUEL_ADAPTERS.frozen?
+      end
+
+      def test_sequel_adapters_contains_postgresql_mapping
+        expected = RUBY_ENGINE == "jruby" ? "postgresql" : "postgres"
+        assert_equal expected, SequelAdapter::SEQUEL_ADAPTERS["postgresql"]
+      end
+
+      def test_sequel_adapters_contains_mysql2_mapping
+        expected = RUBY_ENGINE == "jruby" ? "mysql" : "mysql2"
+        assert_equal expected, SequelAdapter::SEQUEL_ADAPTERS["mysql2"]
+      end
+
+      def test_sequel_adapters_contains_sqlite3_mapping
+        assert_equal "sqlite", SequelAdapter::SEQUEL_ADAPTERS["sqlite3"]
+      end
+
+      def test_sequel_adapters_contains_oracle_enhanced_mapping
+        assert_equal "oracle", SequelAdapter::SEQUEL_ADAPTERS["oracle_enhanced"]
+      end
+
+      def test_sequel_adapters_contains_sqlserver_mapping
+        expected = RUBY_ENGINE == "jruby" ? "mssql" : "tinytds"
+        assert_equal expected, SequelAdapter::SEQUEL_ADAPTERS["sqlserver"]
+      end
+
+      # Tests for sequel_adapter method
+      def test_sequel_adapter_returns_mapped_adapter_for_known_adapters
+        # Test that it correctly maps the current adapter
+        result = SequelAdapter.sequel_adapter
+        assert_kind_of String, result
+        refute_empty result
+      end
+
+      def test_sequel_adapter_returns_activerecord_adapter_for_unknown_adapters
+        # Stub the activerecord_adapter to return an unknown adapter
+        SequelAdapter.stub(:activerecord_adapter, "custom_db") do
+          assert_equal "custom_db", SequelAdapter.sequel_adapter
+        end
+      end
+
+      # Tests for db method
+      def test_db_returns_sequel_database_connection
+        result = SequelAdapter.db
+        assert_instance_of Sequel::Database, result
+      end
+
+      def test_db_raises_helpful_error_on_failure
+        # Stub sequel_adapter to return an invalid adapter
+        SequelAdapter.stub(:sequel_adapter, "invalid_nonexistent_adapter_xyz") do
+          error = assert_raises(RuntimeError) do
+            SequelAdapter.db
+          end
+          assert_match(/Failed to initialize Sequel/, error.message)
+          assert_match(/invalid_nonexistent_adapter_xyz/, error.message)
+        end
+      end
+
+      # Tests for activerecord_adapter detection
+      def test_activerecord_adapter_detection_works
+        # This test verifies that we can detect the current adapter
+        # The test environment should have a valid database config
+        result = SequelAdapter.sequel_adapter
+        assert_kind_of String, result
+        refute_empty result
+      end
+
+      # Integration test
+      def test_full_integration_with_active_record
+        # Verify the full chain works: detect AR adapter -> map to Sequel -> create connection
+        db = SequelAdapter.db
+        assert_instance_of Sequel::Database, db
+        assert_respond_to db, :run
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a dynamic approach for configuring Sequel to reuse ActiveRecord's database connection in Rodauth, making the setup more robust to database changes and reducing manual intervention. The main improvement is the addition of a new adapter detection module, which allows the Rodauth plugin to automatically select the correct Sequel adapter at runtime.

**Dynamic Sequel adapter detection and configuration:**

* Added `lib/plutonium/auth/sequel_adapter.rb`, which provides the `Plutonium::Auth::SequelAdapter` module for runtime detection of the appropriate Sequel adapter based on the current ActiveRecord configuration. This supports seamless database changes without requiring regeneration of Rodauth files.
* Updated the Rodauth plugin template (`lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt`) to use `Plutonium::Auth::SequelAdapter.db` for database initialization, replacing the previous static adapter logic.

**Note:**
For existing projects, change the line `db Sequel.sqlite(extensions: :activerecord_connection, keep_reference: false)` to `db Plutonium::Auth::SequelAdapter.db`.

Fixes #48 