### PR TITLE
fix(ui): let action dropdowns size to their longest label

### DIFF
--- a/lib/plutonium/ui/action_button.rb
+++ b/lib/plutonium/ui/action_button.rb
@@ -97,7 +97,7 @@ module Plutonium
         end
 
         a(**@action.link_attributes(link_attrs)) do
-          render @action.icon.new(class: "w-4 h-4") if @action.icon
+          render @action.icon.new(class: "w-4 h-4 shrink-0") if @action.icon
           span { @action.label }
         end
       end

--- a/lib/plutonium/ui/actions_dropdown.rb
+++ b/lib/plutonium/ui/actions_dropdown.rb
@@ -34,7 +34,7 @@ module Plutonium
 
       def render_dropdown_menu
         div(
-          class: "hidden absolute right-0 z-50 mt-2 w-48 origin-top-right bg-[var(--pu-surface)] border border-[var(--pu-border)] rounded-[var(--pu-radius-lg)] overflow-hidden",
+          class: "hidden absolute right-0 z-50 mt-2 w-max min-w-48 max-w-[min(20rem,90vw)] origin-top-right bg-[var(--pu-surface)] border border-[var(--pu-border)] rounded-[var(--pu-radius-lg)] overflow-hidden",
           style: "box-shadow: var(--pu-shadow-lg)",
           data: {resource_drop_down_target: "menu"}
         ) do

--- a/lib/plutonium/ui/export_button.rb
+++ b/lib/plutonium/ui/export_button.rb
@@ -63,7 +63,7 @@ module Plutonium
 
       def render_menu
         div(
-          class: "hidden absolute right-0 top-full z-50 mt-1 w-48 origin-top-right bg-[var(--pu-surface)] " \
+          class: "hidden absolute right-0 top-full z-50 mt-1 w-max min-w-48 max-w-[min(20rem,90vw)] origin-top-right bg-[var(--pu-surface)] " \
                  "border border-[var(--pu-border)] rounded-[var(--pu-radius-lg)] overflow-hidden",
           style: "box-shadow: var(--pu-shadow-lg)",
           data: {resource_drop_down_target: "menu"}

--- a/lib/plutonium/ui/table/components/row_actions_dropdown.rb
+++ b/lib/plutonium/ui/table/components/row_actions_dropdown.rb
@@ -34,7 +34,7 @@ module Plutonium
 
           def render_dropdown_menu
             div(
-              class: "hidden absolute right-0 z-50 mt-1 w-40 origin-top-right bg-[var(--pu-surface)] border border-[var(--pu-border)] rounded-[var(--pu-radius-md)] overflow-hidden",
+              class: "hidden absolute right-0 z-50 mt-1 w-max min-w-40 max-w-[min(20rem,90vw)] origin-top-right bg-[var(--pu-surface)] border border-[var(--pu-border)] rounded-[var(--pu-radius-md)] overflow-hidden",
               style: "box-shadow: var(--pu-shadow-lg)",
               data: {resource_drop_down_target: "menu"}
             ) do


### PR DESCRIPTION
## Problem

Action dropdown menus are pinned to a fixed width (`w-48` / `w-40`), so any label longer than ~12rem wraps onto a second line even when there's plenty of room beside it — e.g. "Hide from search engines" wrapping under a half-empty menu.

## Change

Swap the fixed width for intrinsic sizing on all three dropdowns:

```
w-max min-w-48 max-w-[min(20rem,90vw)]
```

- `w-max` — sizes to the longest label, no wrapping
- `min-w-*` — preserves the current look when labels are short
- `max-w-[min(20rem,90vw)]` — a pathological label wraps instead of running off screen

This is safe because the menus are teleported to `<body>` and positioned by popper's `fixed` strategy, so no ancestor constrains their width, and `preventOverflow` already keeps them inside the viewport. It mirrors the pattern the breadcrumb overflow menu already uses.

Dropdown item icons get `shrink-0` so they aren't squeezed if a label does hit the cap and wrap.

Touched:
- `lib/plutonium/ui/actions_dropdown.rb`
- `lib/plutonium/ui/table/components/row_actions_dropdown.rb`
- `lib/plutonium/ui/export_button.rb`
- `lib/plutonium/ui/action_button.rb`

All three were applied together — fixing only one would leave the others to drift.

## Verification

- Ran the CSS build against this branch and confirmed Tailwind emits every new utility, including the arbitrary value (survives as `.max-w-\[min\(20rem\,90vw\)\]` — the nested `min()` and its comma escape fine).
- `test/plutonium/ui/action_button_test.rb` — 7 runs, 14 assertions, 0 failures.
- No browser check; this is a class-level change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)