### PR TITLE
fix(auth): isolate Rodauth session state per configuration

### DIFF
--- a/.claude/skills/plutonium-auth/SKILL.md
+++ b/.claude/skills/plutonium-auth/SKILL.md
@@ -222,6 +222,39 @@ For portal wiring (`AdminPortal::Concerns::Controller`), see [[plutonium-app]] �
 
 ---
 
+## Multiple portals in one browser
+
+Each portal authenticates through its own Rodauth configuration, and a person can hold a session in several at once — sign into the admin portal and the customer portal in the same browser without either evicting the other.
+
+Two settings make that work, and the generators emit both:
+
+```ruby
+# app/rodauth/rodauth_plugin.rb — the shared base
+configure do
+  enable :session_isolation
+end
+
+# app/rodauth/<name>_rodauth_plugin.rb — once per account type
+configure do
+  session_key_prefix "admin_"
+  remember_cookie_key "_admin_remember"
+end
+```
+
+🚨 **Both are required.** `session_key_prefix` namespaces every session key a configuration touches — the account id plus `authenticated_by`, `login_redirect`, `two_factor_auth_setup`, … `session_isolation` uses that prefix to decide ownership and stops a login from clearing the other configurations' keys.
+
+🚨 **Never set `session_key` alongside it.** Explicit values bypass `convert_session_key` (`rodauth/features/base.rb:686`) so they are NOT prefixed — the account id then rotates separately from every other key. A session holding an account id with no `authenticated_by` makes Rodauth raise on every request (`logged_in_via_remember_key?` → `nil.include?`, `remember.rb:175`). A config with no prefix at all is simply not isolated: its keys are the unprefixed defaults, so nothing is carried for it.
+
+**Why:** Rodauth resets the session on every login — including the `remember` feature's `load_memory` autologin — to defend against session fixation, and rodauth-rails implements that as a full `reset_session`. Without `session_isolation`, signing into one portal wipes every other portal's session; and because `RodauthApp#route` calls `load_memory` for *every* configuration on *every* request, the evicted configuration autologins from its remember cookie on the next request and evicts the new one right back. The last `load_memory` in the route block wins permanently, so the other portal can never hold a session at all.
+
+`session_isolation` carries only the *other configurations'* session entries across the reset. The session id is still rotated and application session data is still cleared, so session fixation is still defeated.
+
+**Reading a raw Rodauth session key?** Go through its accessor, never the literal — `session.delete(login_redirect_session_key)`, not `session.delete(:login_redirect)`. With a prefix set, the literal is the wrong key.
+
+**Upgrading an app generated before this existed:** add `enable :session_isolation` once in the base plugin, add `session_key_prefix` to each account plugin, and **delete any existing `session_key "_x_session"` line**. Every key name changes together, so stale session cookies are simply ignored — the safe outcome. Keeping the old `session_key` to preserve logins is exactly what produces the crashing half-migrated session. Only *unremembered* sessions actually drop: `remember_cookie_key` is a cookie name and is not prefixed, so anyone holding a valid `_x_remember` cookie is restored by `load_memory` on their next request.
+
+---
+
 ## Common customizations
 
 All inside the Rodauth `configure do ... end` block in `app/rodauth/<name>_rodauth_plugin.rb`.
@@ -410,6 +443,9 @@ link_to("Profile", profile_url) if respond_to?(:profile_url)
 - **`pu:saas:setup` runs four other generators** — don't re-run portal, profile, welcome, or invites separately.
 - **Profile requires `pu:profile:conn`** — without it, no route, no `profile_url`, no menu link.
 - **Users need a profile row.** Add an `after_create` callback (or `find_or_create_by`) — `current_user.profile` is otherwise nil.
+- **Concurrent portal logins need `enable :session_isolation` + `session_key_prefix`.** Missing either and signing into one portal silently evicts the others — see Multiple portals in one browser.
+- **Never hardcode a Rodauth session key.** Use the accessor (`login_redirect_session_key`), since `session_key_prefix` changes the literal.
+- **"Remember me" is opt-in.** Configs use `after_login { remember_login if param_or_nil(remember_param) == remember_remember_param_value }` and the login form renders the checkbox. Compare against the value, not just presence — a bare truthiness check means `remember=disable` would remember you. Plutonium's form also passes `include_hidden: false` so an unticked box sends nothing — belt-and-braces next to the value comparison, not the thing holding it up.
 
 ---
 

--- a/.claude/skills/plutonium-tenancy/SKILL.md
+++ b/.claude/skills/plutonium-tenancy/SKILL.md
@@ -613,7 +613,7 @@ configure do
   login_redirect "/welcome"
 
   after_login do
-    session[:after_welcome_redirect] = session.delete(:login_redirect)
+    session[:after_welcome_redirect] = session.delete(login_redirect_session_key)
   end
 end
 ```

--- a/app/views/rodauth/_login_form.html.erb
+++ b/app/views/rodauth/_login_form.html.erb
@@ -34,6 +34,19 @@
       <% end %>
     </div>
     <%= render "password_visibility" %>
+    <%# Only rendered when the config enables `remember`. The box's value is
+        `remember_remember_param_value`, which is what the config's after_login hook
+        compares against. `include_hidden: false` keeps Rails' default "0" off the
+        wire when unticked - belt-and-braces next to that value comparison, but it
+        also keeps this form correct for a config using a bare presence check. %>
+    <% if rodauth.features.include?(:remember) %>
+      <div class="flex items-center space-x-2">
+        <%= form.check_box rodauth.remember_param,
+                       {id: "remember", class: "pu-checkbox", include_hidden: false},
+                       rodauth.remember_remember_param_value %>
+        <%= form.label "remember", rodauth.remember_remember_label, class: "text-sm text-[var(--pu-text)]" %>
+      </div>
+    <% end %>
   <% end %>
   <%= form.submit rodauth.login_button, class: "w-full pu-btn pu-btn-md pu-btn-primary" %>
 <% end %>

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -115,6 +115,78 @@ include Plutonium::Auth::Rodauth(:user)
 
 See [Reference › App › Portals](/reference/app/portals#controller-concern-auth).
 
+## Multiple portals in one browser
+
+A person can hold a session in several portals at once — signed into the admin portal and the customer portal in the same browser, with neither evicting the other. Two settings make that work, and the generators emit both:
+
+```ruby
+# app/rodauth/rodauth_plugin.rb — the shared base
+configure do
+  enable :session_isolation
+end
+```
+
+```ruby
+# app/rodauth/admin_rodauth_plugin.rb — once per account type
+configure do
+  session_key_prefix "admin_"
+  remember_cookie_key "_admin_remember"
+end
+```
+
+Both are required. `session_key_prefix` namespaces *every* session key a configuration touches — the account id plus `authenticated_by`, `login_redirect`, `two_factor_auth_setup` and the rest. `session_isolation` uses that prefix to decide which entries belong to whom, and stops one configuration's login from clearing another's.
+
+::: danger Do not also set `session_key`
+An explicit `session_key` is **not** prefixed (`convert_session_key`, `rodauth/features/base.rb:686` — only the default value passes through it). Setting both leaves the account id on a different name from every other key, so they stop rotating together. A session that holds an account id but no `authenticated_by` makes Rodauth raise on *every request* — `logged_in_via_remember_key?` calls `nil.include?` (`remember.rb:175`).
+
+A config without a prefix at all is also not isolated: its keys are Rodauth's unprefixed defaults, indistinguishable from any other unprefixed config's, so `session_isolation` carries nothing for it.
+:::
+
+::: details Why this is needed
+Rodauth resets the session on every login — including the `remember` feature's `load_memory` autologin — to defend against session fixation, and rodauth-rails implements that reset as a full `reset_session`.
+
+Without `session_isolation`, signing into one portal wipes every other portal's session. And because `RodauthApp#route` calls `load_memory` for *every* configuration on *every* request, the evicted configuration immediately autologins from its remember cookie and evicts the new one right back. The last `load_memory` call in the route block wins permanently, so the other portal can never hold a session at all.
+
+`session_isolation` carries only the *other configurations'* session entries across the reset. The session id is still rotated and application session data is still cleared, so session fixation is still defeated.
+:::
+
+Reading a raw Rodauth session key? Go through its accessor, never the literal — with a prefix set, the literal is the wrong key:
+
+```ruby
+after_login do
+  session[:after_welcome_redirect] = session.delete(login_redirect_session_key) # ✅
+  session[:after_welcome_redirect] = session.delete(:login_redirect)            # ❌ wrong key
+end
+```
+
+**Upgrading an app generated before this existed:** add `enable :session_isolation` once in the base plugin and `session_key_prefix` in each account plugin — and **delete the existing `session_key "_x_session"` line** while you're there, for the reason above.
+
+Every key name changes together, so old session cookies stop matching and are ignored — the safe outcome. Keeping the old `session_key` to "preserve" logins is what produces the half-migrated session that crashes.
+
+In practice only *unremembered* sessions drop: `remember_cookie_key` is a cookie name and isn't touched by the prefix, so anyone holding a valid `_x_remember` cookie is restored by `load_memory` on their next request, which writes the new prefixed keys. Expect logouts for users who never ticked "Remember Me", not a full sign-out.
+
+## "Remember me" is opt-in
+
+The login form renders a "Remember Me" checkbox whenever the config enables the `remember` feature, and the config only issues the 14-day cookie when it's ticked:
+
+```ruby
+after_login { remember_login if param_or_nil(remember_param) == remember_remember_param_value }
+```
+
+To go back to remembering everyone whether they asked or not, swap in the unconditional form:
+
+```ruby
+after_login { remember_login }
+```
+
+::: warning Compare the value, don't just check presence
+`param_or_nil(remember_param)` on its own is a truthiness check, and `remember_param` is shared with Rodauth's `/remember` settings page — which submits `forget` and `disable` as well as `remember`. A bare presence check means `remember=disable` would remember you. Compare against `remember_remember_param_value`, as above.
+
+Plutonium's login form also passes `include_hidden: false` to `check_box`, so an unticked box sends nothing at all rather than Rails' default `"0"`. With the value comparison that's belt-and-braces rather than load-bearing (`"0" == "remember"` is already false) — but it keeps a junk param off the wire and keeps the form correct for anyone who reverts the hook to a bare truthiness check.
+:::
+
+Logged-in users can change the setting later on Rodauth's `/remember` page (Remember / Forget / Disable).
+
 ## Customizing the auth flow
 
 All inside `app/rodauth/<name>_rodauth_plugin.rb`, in the `configure do` block:
@@ -185,6 +257,7 @@ user
 - **"You need to set up Rodauth"** — run `pu:rodauth:install` first.
 - **Portal redirects to login even though you're authenticated** — the portal mount constraint references a different Rodauth account than the portal's controller concern uses. Match them up.
 - **Email confirmation never arrives in development** — Plutonium sets ActionMailer to `:test` by default. Check `tmp/letter_opener/` or your mail interceptor. In production, configure SMTP (see above).
+- **Signing into one portal signs you out of another** — or one portal can never stay signed in at all. Missing `enable :session_isolation` and/or `session_key_prefix`; see [Multiple portals in one browser](#multiple-portals-in-one-browser).
 
 ## Related
 

--- a/docs/guides/user-invites.md
+++ b/docs/guides/user-invites.md
@@ -73,7 +73,7 @@ configure do
   login_redirect "/welcome"
 
   after_login do
-    session[:after_welcome_redirect] = session.delete(:login_redirect)
+    session[:after_welcome_redirect] = session.delete(login_redirect_session_key)
   end
 end
 ```

--- a/docs/reference/auth/accounts.md
+++ b/docs/reference/auth/accounts.md
@@ -228,6 +228,25 @@ before_create_account_route do
 end
 ```
 
+### Session isolation (multiple account types)
+
+Emitted by the generators; both parts are required for concurrent portal logins.
+
+```ruby
+# app/rodauth/rodauth_plugin.rb — the shared base, once
+enable :session_isolation
+```
+
+```ruby
+# app/rodauth/<name>_rodauth_plugin.rb — once per account type
+session_key_prefix "admin_"           # namespaces EVERY key, account id included
+remember_cookie_key "_admin_remember"
+```
+
+Drop either and signing into one portal evicts the others.
+
+Do **not** also set `session_key`: explicit values bypass `convert_session_key` and so are not prefixed, leaving the account id rotating separately from every other key. Rodauth then raises on any session holding an account id with no `authenticated_by`. See [Guides › Authentication › Multiple portals in one browser](/guides/authentication#multiple-portals-in-one-browser).
+
 ## Related
 
 - [Profile](./profile) — profile resource + SecuritySection component

--- a/docs/reference/tenancy/invites.md
+++ b/docs/reference/tenancy/invites.md
@@ -161,7 +161,7 @@ configure do
   login_redirect "/welcome"
 
   after_login do
-    session[:after_welcome_redirect] = session.delete(:login_redirect)
+    session[:after_welcome_redirect] = session.delete(login_redirect_session_key)
   end
 end
 ```

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    plutonium (0.62.1)
+    plutonium (0.62.2)
       action_policy (~> 0.7.0)
       csv
       listen (~> 3.8)

--- a/lib/generators/pu/invites/install_generator.rb
+++ b/lib/generators/pu/invites/install_generator.rb
@@ -329,7 +329,7 @@ module Pu
           new_block = <<~RUBY.chomp
             #{indent}after_login do
             #{indent}  #{existing_code}
-            #{indent}  session[:after_welcome_redirect] = session.delete(:login_redirect)
+            #{indent}  session[:after_welcome_redirect] = session.delete(login_redirect_session_key)
             #{indent}end
           RUBY
 
@@ -345,7 +345,7 @@ module Pu
           new_block = <<~RUBY.chomp
             #{indent}after_login do
             #{block_content}
-            #{indent}  session[:after_welcome_redirect] = session.delete(:login_redirect)
+            #{indent}  session[:after_welcome_redirect] = session.delete(login_redirect_session_key)
             #{end_indent}end
           RUBY
 
@@ -357,7 +357,7 @@ module Pu
 
     # ==> User Invites - Move captured path to session for WelcomeController
     after_login do
-      session[:after_welcome_redirect] = session.delete(:login_redirect)
+      session[:after_welcome_redirect] = session.delete(login_redirect_session_key)
     end
           RUBY
 

--- a/lib/generators/pu/rodauth/templates/app/rodauth/account_rodauth_plugin.rb.tt
+++ b/lib/generators/pu/rodauth/templates/app/rodauth/account_rodauth_plugin.rb.tt
@@ -233,11 +233,11 @@ class <%= account_path.classify %>RodauthPlugin < RodauthPlugin
 
     # ==> Remember Feature
 
-    # Remember all logged in users.
-    after_login { remember_login }
+    # Only remember users who ticked the "Remember Me" checkbox on the login form.
+    after_login { remember_login if param_or_nil(remember_param) == remember_remember_param_value }
 
-    # Or only remember users that have ticked a "Remember Me" checkbox on login.
-    # after_login { remember_login if param_or_nil("remember") }
+    # Or remember every user who logs in, whether they asked to be or not.
+    # after_login { remember_login }
 
     # Extend user's remember period when remembered via a cookie
     extend_remember_deadline? true
@@ -246,8 +246,17 @@ class <%= account_path.classify %>RodauthPlugin < RodauthPlugin
     remember_cookie_key "_<%= table_prefix %>_remember"
 <% end -%>
 
-    # Session security
-    session_key "_<%= table_prefix %>_session"
+    # Session security: namespace EVERY session key this configuration touches -
+    # the account id plus `authenticated_by`, `login_redirect`,
+    # `two_factor_auth_setup` and friends. Without this, configurations share those
+    # keys and clobber each other's state, and `session_isolation` cannot tell which
+    # entries belong to which configuration.
+    #
+    # Do not also set `session_key` here. An explicit `session_key` is NOT prefixed,
+    # so the account id key would rotate on a different schedule from every other
+    # key - and Rodauth crashes on a session that has an account id but no
+    # `authenticated_by` (`nil.include?` in `logged_in_via_remember_key?`).
+    session_key_prefix "<%= table_prefix %>_"
 
     # ==> Hooks
 

--- a/lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt
+++ b/lib/generators/pu/rodauth/templates/app/rodauth/rodauth_plugin.rb.tt
@@ -9,6 +9,13 @@ class RodauthPlugin < Rodauth::Rails::Auth
     # See the Rodauth documentation for the list of available config options:
     # http://rodauth.jeremyevans.net/documentation.html
 
+    # Keep each configuration's session state to itself, so a person can be signed
+    # into more than one portal at a time. Without this, Rodauth's session reset on
+    # login (and on the `remember` feature's autologin) wipes the whole Rails
+    # session, evicting every other configuration's login.
+    # Relies on each configuration setting `session_key_prefix`.
+    enable :session_isolation
+
     # List of authentication features that are loaded.
     # enable :create_account, :verify_account, :verify_account_grace_period,
     #   :reset_password, :change_password, :change_password_notify,

--- a/lib/rodauth/features/session_isolation.rb
+++ b/lib/rodauth/features/session_isolation.rb
@@ -1,0 +1,92 @@
+require "rodauth"
+
+# Keeps each Rodauth configuration's session state independent of the others, so a
+# person can be signed into more than one portal at a time.
+#
+# Rodauth calls +clear_session+ from +update_session+ on *every* login - including
+# the +remember+ feature's +load_memory+ autologin - to defend against session
+# fixation. rodauth-rails implements that as a full +reset_session+, which drops the
+# entire Rails session rather than just the keys belonging to the configuration
+# doing the login.
+#
+# In a Plutonium app that breaks multi-portal access. Each portal authenticates
+# through its own configuration (+:user+, +:admin+, ...), so signing into one portal
+# evicts every other portal's session. Worse, with +after_login { remember_login }+
+# enabled the +load_memory+ calls in +RodauthApp#route+ then re-authenticate the
+# evicted configuration from its remember cookie on the very next request - and
+# evict the new one in turn. The last +load_memory+ in the route block wins
+# permanently, so the other portal can never hold a session at all.
+#
+# This feature carries the *other* configurations' session entries across the
+# reset. The Rails session id is still rotated and this configuration's own state is
+# still dropped, so session fixation is still defeated; application session data is
+# still cleared, exactly as before.
+#
+# Ownership is decided by +session_key_prefix+, so every configuration that wants to
+# coexist must set one. A configuration without a prefix uses Rodauth's unprefixed
+# default key names - the same names every other unprefixed configuration uses - so
+# there is no way to tell its entries apart and nothing is carried for it.
+module Rodauth
+  Feature.define(:session_isolation, :SessionIsolation) do
+    def clear_session
+      carried = sibling_session_data
+      super
+      carried.each { |key, value| session[key] = value }
+    end
+
+    private
+
+    # The session entries owned by the app's other Rodauth configurations.
+    #
+    # Keys are matched by prefix rather than by asking each configuration to
+    # enumerate them. Deriving them from method names (e.g. everything matching
+    # /_session_key\z/) would mean blind-sending methods that are not readers at
+    # all: +single_session+ exposes +reset_single_session_key+ and
+    # +update_single_session_key+ as public auth methods, both of which UPDATE the
+    # database with a fresh random key - signing the sibling out, the exact opposite
+    # of this feature's purpose.
+    def sibling_session_data
+      data = session.to_hash
+
+      sibling_rodauths.each_with_object({}) do |sibling, carried|
+        prefix = sibling.session_key_prefix.to_s
+        # Unprefixed sibling: its key names are indistinguishable from ours, and
+        # carrying them would restore our own pre-login auth state across the reset,
+        # defeating the session fixation protection.
+        next if prefix.empty?
+
+        keys = data.keys.select { |key| key.to_s.start_with?(prefix) }
+        # Courtesy for a hand-written config that sets an explicit `session_key`
+        # alongside its prefix: that value bypasses `convert_session_key` and so is
+        # unprefixed. Do NOT read this as endorsing that shape - it leaves the account
+        # id rotating separately from every other key, which is a crash waiting to
+        # happen (see the note on session_key_prefix in the auth guide). Generated
+        # configs set the prefix only, and for them this line never matches.
+        account_key = sibling.session_key.to_s
+        keys << account_key if data.key?(account_key)
+
+        keys.each do |key|
+          carried[key] = data[key] unless own_session_key?(key)
+        end
+      end
+    end
+
+    # Guards against a misconfiguration in which a sibling shares our prefix: we must
+    # never restore our own entries, or the reset would be a no-op for us.
+    def own_session_key?(key)
+      key = key.to_s
+      return true if key == session_key.to_s
+
+      prefix = session_key_prefix.to_s
+      prefix.present? && key.start_with?(prefix)
+    end
+
+    # Only base-Rodauth methods are called on siblings (+session_key_prefix+ and
+    # +session_key+), so configurations that do not enable this feature - or do not
+    # descend from the app's base plugin at all - still work.
+    def sibling_rodauths
+      names = scope.opts[:rodauths].keys - [self.class.configuration_name]
+      names.map { |name| scope.rodauth(name) }
+    end
+  end
+end

--- a/lib/rodauth/plugins.rb
+++ b/lib/rodauth/plugins.rb
@@ -1,1 +1,2 @@
 require_relative "features/case_insensitive_login"
+require_relative "features/session_isolation"

--- a/test/dummy/app/rodauth/admin_rodauth_plugin.rb
+++ b/test/dummy/app/rodauth/admin_rodauth_plugin.rb
@@ -144,11 +144,11 @@ class AdminRodauthPlugin < RodauthPlugin
 
     # ==> Remember Feature
 
-    # Remember all logged in users.
-    after_login { remember_login }
+    # Only remember users who ticked the "Remember Me" checkbox on the login form.
+    after_login { remember_login if param_or_nil(remember_param) == remember_remember_param_value }
 
-    # Or only remember users that have ticked a "Remember Me" checkbox on login.
-    # after_login { remember_login if param_or_nil("remember") }
+    # Or remember every user who logs in, whether they asked to be or not.
+    # after_login { remember_login }
 
     # Extend user's remember period when remembered via a cookie
     extend_remember_deadline? true
@@ -156,8 +156,11 @@ class AdminRodauthPlugin < RodauthPlugin
     # Store the user's remember cookie under a namespace
     remember_cookie_key "_admin_remember"
 
-    # Session security
-    session_key "_admin_session"
+    # Session security: namespace EVERY session key this configuration touches.
+    # Do not also set `session_key` - an explicit value is NOT prefixed, so the
+    # account id would rotate separately from the rest, and Rodauth crashes on a
+    # session holding an account id with no `authenticated_by`.
+    session_key_prefix "admin_"
 
     # ==> Hooks
 

--- a/test/dummy/app/rodauth/rodauth_plugin.rb
+++ b/test/dummy/app/rodauth/rodauth_plugin.rb
@@ -8,6 +8,10 @@ class RodauthPlugin < Rodauth::Rails::Auth
     # See the Rodauth documentation for the list of available config options:
     # http://rodauth.jeremyevans.net/documentation.html
 
+    # Keep each configuration's session state independent, so a user can be
+    # signed into more than one portal at a time.
+    enable :session_isolation
+
     # List of authentication features that are loaded.
     # enable :create_account, :verify_account, :verify_account_grace_period,
     #   :reset_password, :change_password, :change_password_notify,

--- a/test/dummy/app/rodauth/user_rodauth_plugin.rb
+++ b/test/dummy/app/rodauth/user_rodauth_plugin.rb
@@ -137,11 +137,11 @@ class UserRodauthPlugin < RodauthPlugin
 
     # ==> Remember Feature
 
-    # Remember all logged in users.
-    after_login { remember_login }
+    # Only remember users who ticked the "Remember Me" checkbox on the login form.
+    after_login { remember_login if param_or_nil(remember_param) == remember_remember_param_value }
 
-    # Or only remember users that have ticked a "Remember Me" checkbox on login.
-    # after_login { remember_login if param_or_nil("remember") }
+    # Or remember every user who logs in, whether they asked to be or not.
+    # after_login { remember_login }
 
     # Extend user's remember period when remembered via a cookie
     extend_remember_deadline? true
@@ -149,8 +149,11 @@ class UserRodauthPlugin < RodauthPlugin
     # Store the user's remember cookie under a namespace
     remember_cookie_key "_user_remember"
 
-    # Session security
-    session_key "_user_session"
+    # Session security: namespace EVERY session key this configuration touches.
+    # Do not also set `session_key` - an explicit value is NOT prefixed, so the
+    # account id would rotate separately from the rest, and Rodauth crashes on a
+    # session holding an account id with no `authenticated_by`.
+    session_key_prefix "user_"
 
     # ==> Hooks
 

--- a/test/generators/invites_install_generator_test.rb
+++ b/test/generators/invites_install_generator_test.rb
@@ -525,7 +525,15 @@ class InvitesInstallGeneratorTest < Rails::Generators::TestCase
     assert_file "app/rodauth/user_rodauth_plugin.rb" do |content|
       # Should add session redirect to existing after_login block
       assert_match(/after_welcome_redirect/, content)
-      assert_match(/session\[:after_welcome_redirect\] = session\.delete\(:login_redirect\)/, content)
+      assert_match(/session\[:after_welcome_redirect\] = session\.delete\(login_redirect_session_key\)/, content)
+      # The fixture carries the hook exactly as pu:rodauth:account emits it, and the
+      # generator rewrites that single line into a block. Pin the condition surviving
+      # verbatim: the parser is a regex (`install_generator.rb`), so a longer emitted
+      # line is a real seam.
+      assert_match(
+        /after_login do\s*\n\s*remember_login if param_or_nil\(remember_param\) == remember_remember_param_value\s*\n/,
+        content
+      )
       # Should update login_redirect to /welcome
       assert_match(/login_redirect "\/welcome"/, content)
       # Should add create_account_redirect
@@ -551,14 +559,17 @@ class InvitesInstallGeneratorTest < Rails::Generators::TestCase
   test "configures rodauth with multi-line after_login block" do
     rodauth_file = destination_root.join("app/rodauth/user_rodauth_plugin.rb")
 
-    # Replace single-line with multi-line block
+    # Replace the single-line hook with a multi-line block. Anchored to the start of
+    # the line so it can only hit the ACTIVE hook - a plain string match would also
+    # rewrite the commented-out alternative underneath it, un-commenting live code and
+    # closing `configure do` early. The assertion below makes a silent no-op (this test
+    # then exercising the single-line branch instead) impossible.
     content = File.read(rodauth_file)
-    content.gsub!("after_login { remember_login }", <<~RUBY.strip)
-      after_login do
-          remember_login
-          log_login_event
-        end
-    RUBY
+    replaced = content.sub!(/^([ \t]*)after_login \{ .+ \}$/) do
+      indent = $1
+      "#{indent}after_login do\n#{indent}  remember_login\n#{indent}  log_login_event\n#{indent}end"
+    end
+    refute_nil replaced, "fixture no longer contains a single-line after_login hook"
     File.write(rodauth_file, content)
 
     run_generator default_args
@@ -567,7 +578,7 @@ class InvitesInstallGeneratorTest < Rails::Generators::TestCase
       # Should preserve existing code and add our line
       assert_match(/remember_login/, content)
       assert_match(/log_login_event/, content)
-      assert_match(/session\[:after_welcome_redirect\] = session\.delete\(:login_redirect\)/, content)
+      assert_match(/session\[:after_welcome_redirect\] = session\.delete\(login_redirect_session_key\)/, content)
       # Should update login_redirect to /welcome
       assert_match(/login_redirect "\/welcome"/, content)
     end
@@ -576,19 +587,21 @@ class InvitesInstallGeneratorTest < Rails::Generators::TestCase
   test "configures rodauth when no after_login block exists" do
     rodauth_file = destination_root.join("app/rodauth/user_rodauth_plugin.rb")
 
-    # Remove all after_login references
+    # Remove every after_login reference, active and commented, so the generator has
+    # to create a fresh block. Matched loosely on purpose: pinning this to the
+    # template's exact wording makes the setup silently become a no-op whenever the
+    # template is reworded, and the assertions below then test the wrong branch.
     content = File.read(rodauth_file)
-    content.gsub!(/^\s*after_login \{ remember_login \}\n/, "")
-    content.gsub!(/^\s*# Or only remember.*\n/, "")
-    content.gsub!(/^\s*# after_login \{ remember_login if.*\n/, "")
+    content.gsub!(/^.*after_login.*\n/, "")
     File.write(rodauth_file, content)
+    refute_match(/after_login/, File.read(rodauth_file))
 
     run_generator default_args
 
     assert_file "app/rodauth/user_rodauth_plugin.rb" do |content|
       # Should create new after_login block with only our code
       assert_match(/after_login do/, content)
-      assert_match(/session\[:after_welcome_redirect\] = session\.delete\(:login_redirect\)/, content)
+      assert_match(/session\[:after_welcome_redirect\] = session\.delete\(login_redirect_session_key\)/, content)
       # Should NOT have remember_login since it wasn't there before
       refute_match(/after_login do\s*\n\s*remember_login/, content)
       # Should update login_redirect to /welcome

--- a/test/generators/rodauth_account_generator_test.rb
+++ b/test/generators/rodauth_account_generator_test.rb
@@ -50,6 +50,22 @@ class RodauthAccountGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  # `session_key_prefix` namespaces EVERY session key the configuration touches, so
+  # concurrent portal logins can be told apart. An explicit `session_key` must NOT
+  # be emitted alongside it: explicit values are not prefixed, so the account id
+  # would sit on a different name from the rest and Rodauth 500s on a session that
+  # has an account id but no `authenticated_by`.
+  # See lib/rodauth/features/session_isolation.rb.
+  test "generates plugin with namespaced session keys" do
+    run_generator ["TestAccount"]
+
+    assert_file "app/rodauth/test_account_rodauth_plugin.rb" do |content|
+      assert_match(/^\s+session_key_prefix "test_account_"/, content)
+      assert_match(/^\s+remember_cookie_key "_test_account_remember"/, content)
+      refute_match(/^\s+session_key ["']/, content)
+    end
+  end
+
   test "primary option is ignored" do
     # Even with --primary flag, account should be named
     run_generator ["TestAccount", "--primary"]

--- a/test/integration/multi_portal_session_test.rb
+++ b/test/integration/multi_portal_session_test.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Each portal authenticates through its own Rodauth configuration, so a person must
+# be able to hold a session in several portals at once.
+#
+# Rodauth resets the session on every login (and on the `remember` feature's
+# `load_memory` autologin) to defend against session fixation, and rodauth-rails
+# implements that as a full `reset_session`. The `session_isolation` feature narrows
+# that to the configuration doing the login - see
+# lib/rodauth/features/session_isolation.rb.
+class MultiPortalSessionTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+
+  test "signing into the user portal does not evict the admin session" do
+    admin = create_admin!
+    user = create_user!
+
+    post "/admins/login", params: {email: admin.email, password: "password123"}
+    follow_redirect!
+    get "/admin"
+    assert_response :success, "admin should be signed in"
+
+    post "/users/login", params: {email: user.email, password: "password123"}
+    follow_redirect!
+
+    get "/locus"
+    assert_response :success, "user should be signed in"
+
+    get "/admin"
+    assert_response :success, "admin should still be signed in after the user signs in"
+  end
+
+  test "signing into the admin portal does not evict the user session" do
+    admin = create_admin!
+    user = create_user!
+
+    post "/users/login", params: {email: user.email, password: "password123"}
+    follow_redirect!
+    get "/locus"
+    assert_response :success, "user should be signed in"
+
+    post "/admins/login", params: {email: admin.email, password: "password123"}
+    follow_redirect!
+
+    get "/admin"
+    assert_response :success, "admin should be signed in"
+
+    get "/locus"
+    assert_response :success, "user should still be signed in after the admin signs in"
+  end
+
+  # The `remember` feature autologins every configuration on every request via
+  # `RodauthApp#route`. Before session_isolation, that autologin reset the session
+  # and evicted whichever portal had just been used, so the last `load_memory` call
+  # in the route block won permanently.
+  test "remember autologin does not steal the session from the other portal" do
+    admin = create_admin!
+    user = create_user!
+
+    # `remember` must be opted into, otherwise no remember cookie is issued and this
+    # test would not exercise load_memory at all.
+    post "/admins/login", params: {email: admin.email, password: "password123", remember: "remember"}
+    post "/users/login", params: {email: user.email, password: "password123", remember: "remember"}
+    assert_includes cookies.to_hash.keys, "_admin_remember"
+    assert_includes cookies.to_hash.keys, "_user_remember"
+
+    3.times do
+      get "/locus"
+      assert_response :success, "user session should survive the admin's remember autologin"
+      get "/admin"
+      assert_response :success, "admin session should survive the user's remember autologin"
+    end
+  end
+
+  test "signing out of one portal leaves the other signed in" do
+    admin = create_admin!
+    user = create_user!
+
+    post "/admins/login", params: {email: admin.email, password: "password123"}
+    post "/users/login", params: {email: user.email, password: "password123"}
+
+    post "/users/logout"
+
+    get "/locus"
+    assert_response :redirect, "user should be signed out"
+
+    get "/admin"
+    assert_response :success, "admin should still be signed in"
+  end
+
+  test "each configuration namespaces its session keys" do
+    admin = create_admin!
+    user = create_user!
+
+    post "/admins/login", params: {email: admin.email, password: "password123"}
+    post "/users/login", params: {email: user.email, password: "password123"}
+
+    keys = session.to_hash.keys
+    assert_includes keys, "user_account_id"
+    assert_includes keys, "admin_account_id"
+
+    # Every key belongs to exactly one configuration, so the two configurations
+    # cannot read or clobber each other's state.
+    assert_includes keys, "user_authenticated_by"
+    assert_includes keys, "admin_authenticated_by"
+    refute_includes keys, "authenticated_by"
+  end
+
+  # A config's session keys MUST all rotate together. An explicitly configured
+  # `session_key` is NOT prefixed, so setting one alongside `session_key_prefix`
+  # leaves the account id on a different name from every other key. On upgrade that
+  # yields a session holding an account id but no `authenticated_by`, and Rodauth
+  # 500s on every request: `logged_in_via_remember_key?` calls `nil.include?`.
+  #
+  # session_isolation also decides key ownership by prefix, so a config without one
+  # gets nothing carried for it.
+  test "each configuration's account id key carries its own session_key_prefix" do
+    get "/storefront"
+
+    {user: "user_", admin: "admin_"}.each do |name, prefix|
+      rodauth = request.env["rodauth.#{name}"]
+
+      assert_equal prefix, rodauth.session_key_prefix,
+        "#{name} config must set session_key_prefix for session_isolation to own its keys"
+      assert rodauth.session_key.to_s.start_with?(prefix),
+        "#{name} config session_key #{rodauth.session_key.inspect} is missing the " \
+        "#{prefix.inspect} prefix - it must rotate together with every other key"
+    end
+  end
+
+  # Ownership must be derived from `session_key_prefix`, NOT by calling every method
+  # matching /_session_key\z/. That name is not reserved for readers: the
+  # `single_session` feature exposes `reset_single_session_key` and
+  # `update_single_session_key` as public auth methods that UPDATE the database with a
+  # fresh random key - calling them would sign the sibling out, the exact opposite of
+  # what this feature is for. `jwt_session_key` returns nil, which would land as "".
+  test "sibling keys are matched by prefix, not by enumerating reader methods" do
+    get "/storefront"
+    rodauth = request.env["rodauth.user"]
+
+    # A prefixed key no Rodauth reader is named after - method enumeration would miss
+    # it, prefix matching carries it.
+    rodauth.session["admin_key_from_a_feature_we_never_enumerated"] = "carry me"
+    # Ours, and nobody's: neither may be carried.
+    rodauth.session["user_authenticated_by"] = ["password"]
+    rodauth.session["plutonium_wizards"] = {"x" => "y"}
+
+    carried = rodauth.send(:sibling_session_data)
+
+    assert_equal({"admin_key_from_a_feature_we_never_enumerated" => "carry me"}, carried)
+  end
+
+  # A sibling with no prefix uses Rodauth's unprefixed default key names - the same
+  # names we would use without a prefix. Carrying them could restore our own pre-login
+  # auth state across the reset and defeat the session fixation protection.
+  test "nothing is carried for a sibling that has no session_key_prefix" do
+    get "/storefront"
+    rodauth = request.env["rodauth.user"]
+    sibling = request.env["rodauth.admin"]
+
+    rodauth.session["admin_authenticated_by"] = ["password"]
+
+    # Safe to poke: the rodauth instance is per-request and discarded after this test.
+    sibling.define_singleton_method(:session_key_prefix) { nil }
+
+    assert_empty rodauth.send(:sibling_session_data)
+  end
+
+  test "session id still rotates on login, so session fixation is defeated" do
+    admin = create_admin!
+    user = create_user!
+
+    # Establish a session (and a session id) before the login under test.
+    post "/admins/login", params: {email: admin.email, password: "password123"}
+    before = request.session_options[:id].to_s
+    refute_empty before
+
+    post "/users/login", params: {email: user.email, password: "password123"}
+    after = request.session_options[:id].to_s
+
+    refute_empty after
+    refute_equal before, after, "session id must rotate across login"
+  end
+
+  # Only the sibling configurations' auth state is carried across the reset.
+  # Application session data stays pre-auth-plantable, so it must keep being
+  # dropped on login exactly as it was before session_isolation.
+  test "application session data is still cleared on login" do
+    admin = create_admin!
+    user = create_user!
+    org = create_organization!
+    OrganizationUser.create!(organization: org, user: user, role: :owner)
+
+    post "/users/login", params: {email: user.email, password: "password123"}
+    get "/org/#{org.to_param}"
+    assert_response :success
+    assert_includes session.to_hash.keys, "org_portal__scoped_entity_id",
+      "visiting the org portal should remember the scoped entity"
+
+    post "/admins/login", params: {email: admin.email, password: "password123"}
+
+    refute_includes session.to_hash.keys, "org_portal__scoped_entity_id",
+      "application session data should not survive a login"
+    assert_includes session.to_hash.keys, "user_account_id",
+      "the user's auth state should survive the admin login"
+  end
+end

--- a/test/integration/remember_me_opt_in_test.rb
+++ b/test/integration/remember_me_opt_in_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# "Remember me" is opt-in: the login form renders a checkbox, and the configs use
+# `after_login { remember_login if param_or_nil(remember_param) == remember_remember_param_value }`.
+# Logging in without ticking it must not issue a 14-day persistent cookie.
+#
+# The comparison is against the value, not just presence: `remember_param` is shared
+# with Rodauth's /remember settings page, which also submits `forget` and `disable`,
+# so a bare truthiness check would let `remember=disable` remember you.
+class RememberMeOptInTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+
+  test "login form renders a remember me checkbox" do
+    get "/users/login"
+    assert_response :success
+
+    assert_select "input[type=checkbox][name=remember]", 1
+    assert_select "label[for=remember]"
+  end
+
+  # Rails' check_box helper emits a hidden "0" field by default, so an unticked box
+  # still submits `remember=0`. The value comparison in after_login already rejects
+  # that, so this is defence in depth: it keeps a junk param off the wire, and keeps
+  # the form correct for a config that only checks presence.
+  test "remember checkbox does not emit a hidden fallback field" do
+    get "/users/login"
+
+    assert_select "input[type=hidden][name=remember]", 0
+  end
+
+  test "logging in without ticking remember issues no remember cookie" do
+    user = create_user!
+
+    post "/users/login", params: {email: user.email, password: "password123"}
+
+    refute_includes cookies.to_hash.keys, "_user_remember"
+  end
+
+  test "logging in with remember ticked issues a remember cookie" do
+    user = create_user!
+
+    post "/users/login", params: {email: user.email, password: "password123", remember: "remember"}
+
+    assert_includes cookies.to_hash.keys, "_user_remember"
+  end
+
+  # Without a remember cookie there is nothing for load_memory to restore, so the
+  # login must not survive losing the session cookie.
+  test "an unremembered login does not survive session loss" do
+    user = create_user!
+
+    post "/users/login", params: {email: user.email, password: "password123"}
+    get "/locus"
+    assert_response :success
+
+    cookies.delete("_dummy_session")
+    get "/locus"
+    assert_response :redirect, "an unremembered user should be signed out"
+  end
+
+  test "a remembered login survives session loss" do
+    user = create_user!
+
+    post "/users/login", params: {email: user.email, password: "password123", remember: "remember"}
+
+    cookies.delete("_dummy_session")
+    get "/locus"
+    assert_response :success, "a remembered user should be signed back in by load_memory"
+  end
+
+  # The admin config uses `use_multi_phase_login?`, so the password lands on a
+  # second form. The checkbox has to be on that phase, since it is the one that
+  # triggers after_login.
+  test "multi-phase login shows the checkbox on the password phase" do
+    admin = create_admin!
+
+    post "/admins/login", params: {email: admin.email}
+    assert_response :success
+
+    assert_select "input[type=password][name=password]", 1
+    assert_select "input[type=checkbox][name=remember]", 1
+  end
+end


### PR DESCRIPTION
Re-do of #71, containing **only** the auth commit. The breadcrumb change that got swept in there is split out into #72.

## The bug

You could not be signed into two portals at once. Sign into the admin portal, then the user portal, and the user login would not stick.

## Root cause

Rodauth calls `clear_session` from `update_session` on **every** login, to defend against session fixation. rodauth-rails implements that as a full `reset_session` — dropping the *entire* Rails session, not just the keys of the configuration doing the login.

The amplifier: `RodauthApp#route` calls `load_memory` for **every** configuration on **every** request, and the template enabled `remember` unconditionally.

1. Sign in as user. Session reset, user in.
2. Next request: admin isn't logged in, has a remember cookie → autologin → `reset_session` → **user evicted**.
3. Request after: user isn't logged in, has a remember cookie → autologin → **admin evicted**.

The last `load_memory` in the route block wins permanently. In the dummy app that's `:admin`, so the user portal could never hold a session at all.

Confirmed rather than inferred: deleting only the `_admin_remember` cookie made the user login stick.

## The fix

A `session_isolation` Rodauth feature (same pattern as the existing `case_insensitive_login`) narrows `clear_session` to the current configuration, carrying the siblings' entries across the reset. The session id is still rotated and application session data is still cleared, so session fixation is still defeated.

Ownership is derived from `session_key_prefix`, **not** by enumerating `*_session_key` methods. That name is not reserved for readers — `single_session` exposes `reset_single_session_key` and `update_single_session_key` as public auth methods that `UPDATE` the DB with a fresh random key, so calling them would sign the sibling out. A sibling with no prefix uses Rodauth's unprefixed defaults, indistinguishable from our own keys, so nothing is carried for it.

Also in scope:

- **"Remember me" is now opt-in.** The login form renders a checkbox (inside the password block, so it lands on the right phase for `use_multi_phase_login?`), and configs compare against `remember_remember_param_value` rather than testing presence — `remember_param` is shared with Rodauth's `/remember` page, so a bare truthiness check would let `remember=disable` remember you.
- **`login_redirect_session_key`** replaces the `:login_redirect` literal in the invites generator, which becomes the wrong key once a prefix is set.

## ⚠️ Breaking change

Account plugins must set `session_key_prefix` and must **not** set `session_key`. An explicit `session_key` bypasses `convert_session_key` and so is never prefixed, leaving the account id on a different name from every other key. A session holding an account id with no `authenticated_by` makes Rodauth raise on every request (`logged_in_via_remember_key?` → `nil.include?`). Caught by driving the app in a real browser, where a pre-upgrade cookie 500'd every page.

Existing apps:

```ruby
# app/rodauth/rodauth_plugin.rb
enable :session_isolation

# app/rodauth/<name>_rodauth_plugin.rb
session_key_prefix "<name>_"
# and DELETE:  session_key "_<name>_session"
```

Renaming the account-id key signs out users **without** a remember cookie. Anyone holding a valid `_<name>_remember` cookie is restored by `load_memory` on their next request, since `remember_cookie_key` is a cookie name and isn't prefixed. Upgrade notes are in the auth guide and the `plutonium-auth` skill.

## Verification

- **2643 runs, 6529 assertions, 0 failures** on rails-8.0 / 8.1; all 30 generator files pass. (Five fewer than #71 — exactly the breadcrumb tests that moved to #72.)
- `multi_portal_session_test.rb` (10 tests) — 5 fail with the feature disabled. Covers both directions, remember-autologin over repeated requests, logout isolation, session-id rotation still happening, app session data still cleared, and the two otherwise-silent failure modes (prefix-derived ownership, unprefixed-sibling fail-safe).
- `remember_me_opt_in_test.rb` (7 tests) — checkbox rendering incl. the multi-phase password phase, no hidden fallback field, cookie issued only when ticked, session-loss survival both ways.
- Driven in a real browser: fresh context, user login only → `/admin` redirects; then admin login → 18 alternating requests across both portals all 200; `POST /users/logout` leaves the admin session intact; no errors in the log.

## Note for reviewers

`gemfiles/rails_8.0.gemfile.lock` was stale at `plutonium (0.62.1)` while `version.rb` and the other lockfiles are at `0.62.2` — a catch-up, not churn from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
