### PR TITLE
fix(auth): stop a nil entity_scope persisting in the policy context

### DIFF
--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    plutonium (0.62.1)
+    plutonium (0.62.2)
       action_policy (~> 0.7.0)
       csv
       listen (~> 3.8)

--- a/lib/plutonium/core/controllers/authorizable.rb
+++ b/lib/plutonium/core/controllers/authorizable.rb
@@ -48,6 +48,22 @@ module Plutonium
           @current_scoped_entity if scoped_to_entity?
         end
 
+        # Drops ActionPolicy's per-request authorization context memo.
+        #
+        # ActionPolicy builds the context once and memoizes it for the whole request.
+        # Our entity_scope resolves lazily, and the very first authorization of the
+        # request is the scoped entity's own read? check — which runs while
+        # @current_scoped_entity is still nil (see entity_scope_for_authorize above).
+        # That freezes `entity_scope: nil` into the memo, so every later
+        # `policy_for(record:)` / `allowed_to?` that does not pass an explicit
+        # `context:` builds its policy with no entity scope.
+        #
+        # Callers that resolve the scoped entity must invalidate the memo so the
+        # next policy build picks the entity up.
+        def reset_authorization_context!
+          @_authorization_context = nil
+        end
+
         def verify_authorized
           # we don't use action policy's inbuilt checks, so ensure they are neutered,
           # also ensures pundit checks are disabled.

--- a/lib/plutonium/core/controllers/entity_scoping.rb
+++ b/lib/plutonium/core/controllers/entity_scoping.rb
@@ -83,7 +83,11 @@ module Plutonium
           # fetch_current_scoped_entity authorizes while @current_scoped_entity is
           # still nil, which memoizes `entity_scope: nil` into ActionPolicy's
           # per-request context. Drop it now that the entity is available.
-          reset_authorization_context!
+          #
+          # Only when we actually resolved one: a strategy that yields nil leaves
+          # the memo correct as-is, and since nil is not memoized above, resetting
+          # here would re-run the fetch and rebuild the context on every call.
+          reset_authorization_context! if @current_scoped_entity
           @current_scoped_entity
         end
 

--- a/lib/plutonium/core/controllers/entity_scoping.rb
+++ b/lib/plutonium/core/controllers/entity_scoping.rb
@@ -77,8 +77,14 @@ module Plutonium
           # this method might be invoked even when not authenticated.
           # so let's guard against that.
           return unless current_user.present?
+          return @current_scoped_entity if @current_scoped_entity
 
-          @current_scoped_entity ||= fetch_current_scoped_entity
+          @current_scoped_entity = fetch_current_scoped_entity
+          # fetch_current_scoped_entity authorizes while @current_scoped_entity is
+          # still nil, which memoizes `entity_scope: nil` into ActionPolicy's
+          # per-request context. Drop it now that the entity is available.
+          reset_authorization_context!
+          @current_scoped_entity
         end
 
         # Fetches the current scoped entity based on the scoping strategy.

--- a/test/integration/org_portal/entity_scope_context_test.rb
+++ b/test/integration/org_portal/entity_scope_context_test.rb
@@ -79,6 +79,8 @@ class OrgPortal::EntityScopeContextTest < ActionDispatch::IntegrationTest
 
     get "/org/#{other_org.to_param}/catalog/products"
 
-    refute_equal 200, status, "expected no access to an org the user has no membership in"
+    # fetch_entity_from_path scopes by `associated_with(current_user)` and then
+    # `first!`, so a non-member gets RecordNotFound rather than a redirect.
+    assert_response :not_found
   end
 end

--- a/test/integration/org_portal/entity_scope_context_test.rb
+++ b/test/integration/org_portal/entity_scope_context_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "plutonium/testing"
+
+# ActionPolicy memoizes the authorization context for the whole request. Our
+# scoped entity resolves lazily, and the first authorization of the request is
+# the entity's own read? check - which runs while @current_scoped_entity is
+# still nil. Without invalidating that memo, `entity_scope: nil` is frozen in
+# for the rest of the request, and every `policy_for` / `allowed_to?` that does
+# NOT pass an explicit `context:` builds its policy with no tenant.
+#
+# Callers passing an explicit context (current_policy, current_authorized_scope,
+# authorized_resource_scope) were always correct - which is why this stayed
+# hidden. The bare callers are the UI ones: SecureAssociation's inline "+",
+# table row actions, grid cards.
+class OrgPortal::EntityScopeContextTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+  include Plutonium::Testing::AuthHelpers
+
+  setup do
+    @org = create_organization!
+    @user = create_user!
+    create_membership!(organization: @org, user: @user)
+    @category = create_category!
+    create_product!(category: @category, user: @user, organization: @org)
+    login_as(@user, portal: :user)
+  end
+
+  def prefix = "/org/#{@org.to_param}"
+
+  test "the memoized authorization context carries the scoped entity" do
+    get "#{prefix}/catalog/products"
+
+    assert_response :success
+    assert_equal @org, @controller.send(:authorization_context)[:entity_scope]
+  end
+
+  test "policy_for without an explicit context is tenant scoped" do
+    get "#{prefix}/catalog/products"
+
+    assert_response :success
+
+    # The SecureAssociation path verbatim: a picker asks about a *different*
+    # class than the controller's resource and passes no context:.
+    policy = @controller.send(:policy_for, record: Catalog::Category)
+
+    assert_equal @org, policy.entity_scope
+  end
+
+  test "the bare policy_for agrees with current_policy on the entity scope" do
+    get "#{prefix}/catalog/products"
+
+    assert_response :success
+    assert_equal @controller.send(:current_policy).entity_scope,
+      @controller.send(:policy_for, record: Catalog::Product).entity_scope
+  end
+
+  test "a bare authorized_scope is tenant scoped rather than unscoped" do
+    other_org = create_organization!
+    other_user = create_user!
+    create_membership!(organization: other_org, user: other_user)
+    foreign = create_product!(category: @category, user: other_user, organization: other_org)
+
+    get "#{prefix}/catalog/products"
+    assert_response :success
+
+    # `authorized_scope` is a helper_method from ActionPolicy, so host app code
+    # can reach it without going through authorized_resource_scope. With a nil
+    # entity_scope, default_relation_scope falls through to `relation` - i.e.
+    # every tenant's records.
+    scope = @controller.send(:authorized_scope, Catalog::Product.all)
+
+    refute_includes scope.to_a, foreign
+  end
+
+  test "a foreign tenant's entity is still refused" do
+    other_org = create_organization!
+
+    get "/org/#{other_org.to_param}/catalog/products"
+
+    refute_equal 200, status, "expected no access to an org the user has no membership in"
+  end
+end

--- a/test/plutonium/core/controllers/authorizable_test.rb
+++ b/test/plutonium/core/controllers/authorizable_test.rb
@@ -145,4 +145,117 @@ class Plutonium::Core::Controllers::AuthorizableTest < ActiveSupport::TestCase
     assert_equal entity, captured_options[:context][:entity_scope]
     assert_equal "value", captured_options[:context][:custom_key]
   end
+
+  # Unlike TestController above, this one does NOT stub `authorize`, so the real
+  # ActionPolicy authorization_targets are registered and authorization_context
+  # is built for real.
+  class ContextTestController
+    def self.helper_method(*) = nil
+
+    include Plutonium::Core::Controllers::Authorizable
+
+    attr_accessor :current_user
+
+    def scoped_to_entity? = true
+
+    def set_scoped_entity(entity)
+      @current_scoped_entity = entity
+    end
+  end
+
+  test "authorization_context is memoized with a nil entity_scope while the entity resolves" do
+    controller = ContextTestController.new
+    controller.current_user = Object.new
+
+    # The window inside fetch_current_scoped_entity: the entity's own read? check
+    # builds the context before @current_scoped_entity is assigned.
+    assert_nil controller.authorization_context[:entity_scope]
+
+    controller.set_scoped_entity(Object.new)
+
+    # Still stale - ActionPolicy memoizes for the whole request.
+    assert_nil controller.authorization_context[:entity_scope]
+  end
+
+  test "reset_authorization_context! rebuilds the context with the resolved entity_scope" do
+    controller = ContextTestController.new
+    controller.current_user = Object.new
+    entity = Object.new
+
+    assert_nil controller.authorization_context[:entity_scope]
+
+    controller.set_scoped_entity(entity)
+    controller.send(:reset_authorization_context!)
+
+    assert_equal entity, controller.authorization_context[:entity_scope]
+  end
+
+  test "reset_authorization_context! preserves the rest of the context" do
+    controller = ContextTestController.new
+    user = Object.new
+    controller.current_user = user
+
+    controller.authorization_context
+    controller.send(:reset_authorization_context!)
+
+    assert_equal user, controller.authorization_context[:user]
+  end
+
+  # --- ActionPolicy contract -------------------------------------------------
+  #
+  # reset_authorization_context! works by clearing ActionPolicy's memo ivar
+  # directly - the gem exposes no public API for invalidating it. That couples us
+  # to a private internal, and the failure mode is silent: if the ivar moves, the
+  # reset becomes a no-op, entity_scope goes back to nil for every bare
+  # policy_for / allowed_to? / authorized_scope, and default_relation_scope
+  # quietly stops applying tenant scoping (it falls through to the unscoped
+  # `else` branch). No exception, no test failure elsewhere - just a leak.
+  #
+  # These tests pin the internal so a gem upgrade fails here instead.
+
+  test "ActionPolicy memoizes the context into the ivar reset_authorization_context! clears" do
+    controller = ContextTestController.new
+    controller.current_user = Object.new
+
+    before = controller.instance_variables
+    built = controller.authorization_context
+    memo_ivars = (controller.instance_variables - before).select do |ivar|
+      controller.instance_variable_get(ivar) == built
+    end
+
+    assert_equal [:@_authorization_context], memo_ivars,
+      "ActionPolicy's authorization context memo moved. reset_authorization_context! " \
+      "clears @_authorization_context and is now a silent no-op - update it to clear #{memo_ivars.inspect}."
+  end
+
+  test "authorization_context resolves to the implementation reset_authorization_context! targets" do
+    # ActionPolicy defines authorization_context twice, over *different* ivars:
+    #   ActionPolicy::Behaviour            -> @_authorization_context  (wins today)
+    #   ActionPolicy::Behaviours::PolicyFor -> @authorization_context
+    # Behaviour includes PolicyFor and then redefines the method, so Behaviour's
+    # version wins. If that ever inverts, our reset would clear the dead ivar.
+    owner = ContextTestController.instance_method(:authorization_context).owner
+
+    assert_equal ActionPolicy::Behaviour, owner,
+      "authorization_context is now served by #{owner}, which may memoize into a different ivar " \
+      "than the one reset_authorization_context! clears."
+  end
+
+  test "no instance variable retains the stale context after a reset" do
+    # Generic backstop: catches a second/duplicated memo that the reset misses,
+    # without depending on any ivar name.
+    controller = ContextTestController.new
+    controller.current_user = Object.new
+
+    stale = controller.authorization_context
+    controller.set_scoped_entity(Object.new)
+    controller.send(:reset_authorization_context!)
+
+    retained = controller.instance_variables.select do |ivar|
+      controller.instance_variable_get(ivar) == stale
+    end
+
+    assert_empty retained,
+      "#{retained.inspect} still holds the pre-reset authorization context; a bare policy_for would reuse it."
+  end
 end

--- a/test/plutonium/core/controllers/entity_scoping_test.rb
+++ b/test/plutonium/core/controllers/entity_scoping_test.rb
@@ -64,10 +64,9 @@ class Plutonium::Core::Controllers::EntityScopingTest < ActiveSupport::TestCase
 
     # This is the picker path: policy_for(record: SomeClass) with no context:,
     # which falls back to the memoized authorization_context.
-    context = @controller.send(:policy_for, record: Object.new, with: Class.new(Plutonium::Resource::Policy))
-      .instance_variable_get(:@authorization_context)
+    policy = @controller.send(:policy_for, record: Object.new, with: Class.new(Plutonium::Resource::Policy))
 
-    assert_equal @controller.entity, context[:entity_scope]
+    assert_equal @controller.entity, policy.entity_scope
   end
 
   test "current_scoped_entity memoizes and does not re-resolve" do
@@ -86,5 +85,18 @@ class Plutonium::Core::Controllers::EntityScopingTest < ActiveSupport::TestCase
     @controller.current_user = nil
 
     assert_nil @controller.send(:current_scoped_entity)
+  end
+
+  test "a strategy that resolves nothing leaves the authorization context memo intact" do
+    @controller.entity = nil
+
+    assert_nil @controller.send(:current_scoped_entity)
+
+    # The memo built during lookup already says `entity_scope: nil`, which is
+    # correct, so it must survive. nil is not memoized into
+    # @current_scoped_entity, so an unconditional reset would re-resolve and
+    # rebuild the context on every call - and current_scoped_entity is a
+    # helper_method that views call repeatedly.
+    assert_same @controller.context_seen_during_lookup, @controller.authorization_context
   end
 end

--- a/test/plutonium/core/controllers/entity_scoping_test.rb
+++ b/test/plutonium/core/controllers/entity_scoping_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Plutonium::Core::Controllers::EntityScopingTest < ActiveSupport::TestCase
+  # Stands in for the portal engine. A Symbol strategy lets us drive
+  # fetch_current_scoped_entity without a real request/route.
+  class TestEngine
+    def scoped_to_entity? = true
+
+    def scoped_entity_strategy = :lookup_entity
+  end
+
+  class TestController
+    def self.helper_method(*) = nil
+
+    def self.before_action(*, **) = nil
+
+    include Plutonium::Core::Controllers::Authorizable
+    include Plutonium::Core::Controllers::EntityScoping
+
+    attr_accessor :current_user, :entity
+    attr_reader :context_seen_during_lookup
+
+    def current_engine = @current_engine ||= TestEngine.new
+
+    def current_package = nil
+
+    private
+
+    # Simulates the `authorize! scoped_entity, to: :read?` that the :path strategy
+    # performs while @current_scoped_entity is still nil - this is what builds and
+    # memoizes ActionPolicy's authorization context.
+    def lookup_entity
+      @context_seen_during_lookup = authorization_context
+      entity
+    end
+  end
+
+  setup do
+    @controller = TestController.new
+    @controller.current_user = Object.new
+    @controller.entity = Object.new
+  end
+
+  test "current_scoped_entity returns the resolved entity" do
+    assert_equal @controller.entity, @controller.send(:current_scoped_entity)
+  end
+
+  test "the authorization built during lookup sees a nil entity_scope" do
+    @controller.send(:current_scoped_entity)
+
+    assert_nil @controller.context_seen_during_lookup[:entity_scope]
+  end
+
+  test "current_scoped_entity clears the stale authorization context memo" do
+    @controller.send(:current_scoped_entity)
+
+    assert_equal @controller.entity, @controller.authorization_context[:entity_scope]
+  end
+
+  test "policy_for without an explicit context sees the entity_scope" do
+    @controller.send(:current_scoped_entity)
+
+    # This is the picker path: policy_for(record: SomeClass) with no context:,
+    # which falls back to the memoized authorization_context.
+    context = @controller.send(:policy_for, record: Object.new, with: Class.new(Plutonium::Resource::Policy))
+      .instance_variable_get(:@authorization_context)
+
+    assert_equal @controller.entity, context[:entity_scope]
+  end
+
+  test "current_scoped_entity memoizes and does not re-resolve" do
+    calls = 0
+    @controller.define_singleton_method(:lookup_entity) do
+      calls += 1
+      entity
+    end
+
+    3.times { @controller.send(:current_scoped_entity) }
+
+    assert_equal 1, calls
+  end
+
+  test "current_scoped_entity returns nil when there is no current_user" do
+    @controller.current_user = nil
+
+    assert_nil @controller.send(:current_scoped_entity)
+  end
+end


### PR DESCRIPTION
## The bug

ActionPolicy memoizes the authorization context for the whole request:

```ruby
def authorization_context = @_authorization_context ||= build_authorization_context
```

Our scoped entity resolves lazily, and the **first** authorization of a request is the entity's own `read?` check — which runs inside `fetch_current_scoped_entity` while `@current_scoped_entity` is still nil:

```ruby
def fetch_current_scoped_entity
  scoped_entity = fetch_entity_from_path
  authorize! scoped_entity, to: :read?   # builds + memoizes the context here
  scoped_entity                          # only now is @current_scoped_entity assigned
end
```

So `{user: …, entity_scope: nil}` is frozen in for the rest of the request.

## Why it stayed hidden

Callers passing an explicit context always overrode the memo — `current_policy`, `current_authorized_scope`, `authorized_resource_scope` all merge `current_policy_context`. Bare callers did not:

```ruby
context = context ? build_authorization_context.merge(context) : authorization_context
#                   ^ fresh                                       ^ stale
```

`policy_for(record:)`, `allowed_to?` and `authorized_scope` therefore built policies with **no tenant**.

## Impact

**Rule checks fail closed.** A picker's inline `+` (`SecureAssociation#add_url_and_frame`) is hidden from an admin who should see it. Same for `ui/table/resource.rb`, `ui/grid/card.rb`.

**Relation scoping fails OPEN.** With no `entity_scope`, `default_relation_scope` falls through to its unscoped branch:

```ruby
elsif entity_scope
  relation.associated_with(entity_scope)
else
  relation          # ← every tenant
end
```

The integration test in this PR demonstrates it. Reverting the fix:

```
Expected [Product(organization_id: 6), Product(organization_id: 7)]
  to not include Product(organization_id: 7)
```

A bare `authorized_scope` inside an org-6 request returned org 7's records. Note `verify_default_relation_scope_applied!` does **not** catch this — `default_relation_scope` *was* called, it just took the `else`.

**Exposure:** no in-gem call site uses the bare form (all three pass explicit context), so plutonium-core itself did not leak. But `authorized_scope` is an ActionPolicy `helper_method`, reachable from host app controllers, views and components — and the comment at `authorizable.rb:20` ("Use this instead of `authorized_scope` directly") shows the bare call was a live temptation.

## The fix

`current_scoped_entity` assigns the entity, then invalidates the memo. The entity's own `read?` check still sees `entity_scope: nil` — an entity cannot be its own authorization scope — but that state no longer outlives resolution.

Two alternatives were considered and rejected:

- **`SecureAssociation` passing `current_policy_context`** — narrower, and semantically wrong: that context carries `parent`/`parent_association` from the current resource's nested route, which would leak into an unrelated class's policy. Leaves the table/grid/host-app paths broken.
- **Assigning `@current_scoped_entity` before `authorize!`** — makes the entity its own `entity_scope` during its own `read?` check, and leaves it assigned if `authorize!` raises.

## Safety of the change

- Direction is `nil` → correct tenant, never a wrong one: the entity is resolved via `associated_with(current_user)` then `authorize! … to: :read?`. A test asserts a foreign org still 404s.
- No stale policy survives: `nil._policy_cache_key` is `""` vs an entity's `cache_key_with_version`, so `__policies_cache__` / `PerThreadCache` keys diverge across the reset.
- The UI gate was never the boundary — `authorize_current!` always merged the correct context, so this aligns affordance with enforcement rather than relaxing it.

## Tests

| Test | Red without the fix |
|---|---|
| `test/plutonium/core/controllers/entity_scoping_test.rb` (6) | 2, incl. the bare-`policy_for` picker path |
| `test/integration/org_portal/entity_scope_context_test.rb` (5) | 4, incl. the cross-tenant leak |
| `test/plutonium/core/controllers/authorizable_test.rb` (+6) | memo semantics + ActionPolicy contract |

### On the ActionPolicy coupling

`reset_authorization_context!` clears a private ivar because the gem exposes no invalidation API, and that coupling fails **silently** — if the ivar moves, the reset no-ops and the leak returns with no error. Three contract tests pin it:

1. the memo ivar is discovered empirically and compared against the one we clear;
2. the method's owner is pinned, so a resolution change to `Behaviours::PolicyFor` (which memoizes into a *different* ivar, `@authorization_context`) is caught;
3. a name-independent backstop asserts no ivar retains the stale context after a reset.

I verified these actually fire by simulating both failure modes against the suite. Relocating the ivar produces:

```
ActionPolicy's authorization context memo moved. reset_authorization_context!
clears @_authorization_context and is now a silent no-op - update it to clear
[:@relocated_authorization_context].
```

and removing `Behaviour`'s override so `PolicyFor` wins produces:

```
authorization_context is now served by ActionPolicy::Behaviours::PolicyFor,
which may memoize into a different ivar than the one
reset_authorization_context! clears.
```

## Known residual

Anything that authorizes *before* `remember_scoped_entity` still sees `entity_scope: nil` — but that is genuine rather than stale, since the entity is not yet resolved. Not addressable by memo invalidation. If such a caller does relation scoping, it still fails open.

## Verification

`2643 runs, 6492 assertions, 0 failures` on Rails 7, 8.0 and 8.1. `standardrb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
