### PR TITLE
fix(positioning): open rebalance transactions on the model's own connection

### DIFF
--- a/lib/plutonium/positioning.rb
+++ b/lib/plutonium/positioning.rb
@@ -63,7 +63,20 @@ module Plutonium
       def backfill_positions!(order: :created_at)
         groups = positioning_scope_attr ? all.group_by(&positioning_scope_attr) : {nil => all.to_a}
         groups.each_value do |rows|
-          ActiveRecord::Base.transaction do
+          # `transaction` on THIS class, never ActiveRecord::Base.transaction.
+          # A transaction is opened on the RECEIVER's connection pool, while the
+          # UPDATEs below go out on this model's pool (update_column →
+          # self.class._update_record). When the model lives on the primary
+          # database those are the same connection and either form works — but
+          # only by coincidence.
+          #
+          # On a secondary database they are different connections:
+          # ActiveRecord::Base would BEGIN on primary and do nothing else with
+          # it, while every UPDATE autocommits unprotected on the model's own
+          # connection. A crash partway leaves the group half-renumbered, with
+          # duplicate or gapped positions and nothing to roll back. Do not
+          # "simplify" this back.
+          transaction do
             rows.sort_by { |r| r.public_send(order) }.each_with_index do |row, i|
               row.update_column(positioning_column, (i + 1).to_f)
             end
@@ -110,7 +123,13 @@ module Plutonium
 
     def rebalance_scope_group!
       col = self.class.positioning_column
-      ActiveRecord::Base.transaction do
+      # self.class.transaction, never ActiveRecord::Base.transaction — the BEGIN
+      # must land on the connection the UPDATEs below actually use. See the note
+      # in backfill_positions!: on a secondary-database model the
+      # ActiveRecord::Base form opens an empty transaction on primary while every
+      # renumbering UPDATE autocommits unprotected. Rebalancing is exactly where
+      # that matters, since a half-applied renumber corrupts the ordering.
+      self.class.transaction do
         positioning_group_relation.order(col).each_with_index do |row, i|
           row.update_column(col, (i + 1).to_f)
         end

--- a/lib/plutonium/resource/controllers/kanban_actions.rb
+++ b/lib/plutonium/resource/controllers/kanban_actions.rb
@@ -197,7 +197,19 @@ module Plutonium
             @resource_record = record
           end
 
-          ActiveRecord::Base.transaction do
+          # record.class.transaction, never ActiveRecord::Base.transaction — a
+          # transaction opens on the RECEIVER's connection pool, and every write
+          # below (the on_exit/on_enter save!, reposition! and any rebalance it
+          # triggers, the final save!) goes out on the RECORD's pool. For a
+          # resource on a secondary database ActiveRecord::Base would BEGIN on
+          # primary and guard nothing, leaving a failed drop half-applied.
+          #
+          # This is narrower than fully atomic, and deliberately so: a drop
+          # interaction or a user-supplied on_enter can write arbitrary models,
+          # which are covered only if they share the record's connection. Rails
+          # has no two-phase commit across pools, so a write to a model on a
+          # third database cannot be rolled back by any single receiver.
+          record.class.transaction do
             # (1) Apply on_exit (SOURCE column) then on_enter (DESTINATION column),
             # CROSS-column moves only. A same-column reorder skips both (see
             # cross_column above) and only repositions; on_exit/on_enter represent

--- a/test/plutonium/positioning_secondary_database_test.rb
+++ b/test/plutonium/positioning_secondary_database_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+module Plutonium
+  # Regression guard: rebalancing must be ATOMIC on a model that lives on a
+  # SECONDARY database.
+  #
+  # A transaction is opened on the RECEIVER's connection pool.
+  # `ActiveRecord::Base.transaction` therefore BEGINs on primary, while
+  # `row.update_column` issues its UPDATE on the model's OWN pool
+  # (update_column -> update_columns -> self.class._update_record). On a
+  # single-database app those are the same connection and the old code worked
+  # by accident. Put the model on a secondary database and the BEGIN protects
+  # nothing: every renumbering UPDATE autocommits on its own, so a failure
+  # partway through leaves the group half-renumbered — duplicate or gapped
+  # positions with nothing to roll back — while the empty transaction on
+  # primary commits happily.
+  #
+  # The tests below are deliberately BEHAVIOURAL: they blow up in the middle of
+  # a rebalance and assert that NOTHING was renumbered. They assert nothing
+  # about which connection a transaction was opened on, so they survive any
+  # reshaping of the implementation that keeps the guarantee.
+  class PositioningSecondaryDatabaseTest < Minitest::Test
+    # Raised from the update_column seam to abort a rebalance mid-flight.
+    class Boom < StandardError; end
+
+    # A second SQLite file with its own connection pool, standing in for a host
+    # app whose model is on a secondary database via `connects_to`. Declared
+    # with a config hash rather than a database.yml key on purpose: it needs no
+    # change to test/dummy (which the generator tests `git clean`) and it
+    # exercises the same thing connects_to ultimately produces — a model whose
+    # pool is not ActiveRecord::Base's.
+    class SecondaryBase < ActiveRecord::Base
+      self.abstract_class = true
+
+      DATABASE_PATH = File.join(Dir.tmpdir, "plutonium_positioning_secondary_test.sqlite3")
+
+      establish_connection(adapter: "sqlite3", database: DATABASE_PATH)
+    end
+
+    class SecondaryItem < SecondaryBase
+      self.table_name = "secondary_positioning_items"
+      include Plutonium::Positioning
+
+      positioned_on :position, scope: :status
+
+      # Test seam. With +fail_update_column_at+ set to N, the Nth update_column
+      # on this model raises — the cheapest way to die halfway through a
+      # rebalance loop with some rows already written.
+      class << self
+        attr_accessor :fail_update_column_at, :update_column_calls
+      end
+
+      def update_column(*)
+        self.class.update_column_calls += 1
+        raise Boom if self.class.update_column_calls == self.class.fail_update_column_at
+        super
+      end
+    end
+
+    def setup
+      SecondaryItem.fail_update_column_at = nil
+      SecondaryItem.update_column_calls = 0
+      SecondaryItem.with_connection do |c|
+        c.create_table(:secondary_positioning_items, force: true) do |t|
+          t.string :status
+          t.decimal :position, precision: 20, scale: 10
+          t.timestamps
+        end
+      end
+    end
+
+    def teardown
+      SecondaryItem.fail_update_column_at = nil
+      SecondaryItem.with_connection do |c|
+        c.drop_table(:secondary_positioning_items, if_exists: true)
+      end
+    end
+
+    # Sanity check for the harness itself: if these two ever shared a pool the
+    # atomicity tests below would pass vacuously.
+    def test_the_model_really_is_on_a_separate_connection_pool
+      refute_equal ActiveRecord::Base.connection_pool.object_id,
+        SecondaryItem.connection_pool.object_id,
+        "harness is broken: the secondary model shares primary's pool"
+    end
+
+    # ---------------------------------------------------------------- #
+    # backfill_positions! (class method)                                #
+    # ---------------------------------------------------------------- #
+
+    def test_a_failed_backfill_renumbers_nothing_on_a_secondary_database
+      t0 = Time.current
+      10.times { |i| SecondaryItem.create!(status: "todo", position: 99.0, created_at: t0 + i) }
+      before = SecondaryItem.order(:id).pluck(:id, :position)
+
+      fail_at_update_column(4)
+
+      assert_raises(Boom) { SecondaryItem.backfill_positions!(order: :created_at) }
+
+      assert_equal before, SecondaryItem.order(:id).pluck(:id, :position),
+        "a backfill that failed partway must roll back every row it renumbered"
+    end
+
+    # ---------------------------------------------------------------- #
+    # rebalance_scope_group! (instance, driven through reposition!)     #
+    # ---------------------------------------------------------------- #
+
+    def test_a_failed_rebalance_renumbers_nothing_on_a_secondary_database
+      rows = 10.times.map { |i| SecondaryItem.create!(status: "todo", position: (i + 1) * 10.0) }
+
+      # Collapse the gap between the first two rows so reposition! is forced
+      # down the rebalance path rather than simply splitting the interval.
+      tiny = Plutonium::Positioning::EPSILON / 10
+      rows[0].update_column(:position, 1.0)
+      rows[1].update_column(:position, 1.0 + tiny)
+      before = SecondaryItem.order(:id).pluck(:id, :position)
+
+      mover = rows.last
+      fail_at_update_column(4)
+
+      assert_raises(Boom) do
+        mover.reposition!(prev_record: rows[0].reload, next_record: rows[1].reload)
+      end
+
+      assert_equal before, SecondaryItem.order(:id).pluck(:id, :position),
+        "a rebalance that failed partway must leave every position untouched"
+    end
+
+    # Rows in OTHER scope groups are not part of the rebalanced group, so they
+    # must survive either way — this pins down that the rollback doesn't
+    # overreach and undo unrelated work.
+    def test_a_failed_rebalance_leaves_other_scope_groups_alone
+      10.times { |i| SecondaryItem.create!(status: "todo", position: (i + 1) * 10.0) }
+      other = SecondaryItem.create!(status: "done", position: 7.0)
+
+      todo = SecondaryItem.where(status: "todo").order(:position).to_a
+      tiny = Plutonium::Positioning::EPSILON / 10
+      todo[0].update_column(:position, 1.0)
+      todo[1].update_column(:position, 1.0 + tiny)
+
+      fail_at_update_column(4)
+
+      assert_raises(Boom) do
+        todo.last.reposition!(prev_record: todo[0].reload, next_record: todo[1].reload)
+      end
+
+      assert_equal 7.0, other.reload.position.to_f
+    end
+
+    private
+
+    # Arm the seam so the next +n+ th update_column raises. Resets the counter
+    # so the fixture setup above (which itself calls update_column) doesn't
+    # count toward it.
+    def fail_at_update_column(n)
+      SecondaryItem.update_column_calls = 0
+      SecondaryItem.fail_update_column_at = n
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`ActiveRecord::Base.transaction` opens a transaction on the pool belonging to `ActiveRecord::Base` — primary. `row.update_column` issues its UPDATE through `row.class.connection`.

**Same database (the normal case).** Those are the same connection. The `BEGIN` and every `UPDATE` share it, so the rebalance is atomic and a failure halfway rolls the whole thing back. The code is correct — but correct *by accident*, because the receiver happened to name the same connection the writes use.

**Model on a secondary database.** `ActiveRecord::Base.transaction` opens a `BEGIN` on primary and does nothing else with it. The `UPDATE`s go out on the model's own connection, where no transaction is open, so each autocommits on its own. A crash after row 4 of 30 leaves four rows renumbered and twenty-six not, with nothing to roll back — while the empty transaction on primary commits successfully.

Rebalancing is exactly the operation where that matters: a half-applied renumber leaves duplicate or gapped positions.

## Why it's reachable

Not hypothetical. Plutonium's own generators — `pu:lite:solid_queue`, `solid_cache`, `solid_cable`, `solid_errors`, `rails_pulse` — all set up secondary databases via `connects_to`. Any host app that follows that advice *and* uses `Plutonium::Positioning` is exposed.

Latent rather than urgent: it needs both conditions to bite.

## The fix

Name the connection the writes actually use.

| Site | Was | Now |
|---|---|---|
| `backfill_positions!` | `ActiveRecord::Base.transaction` | `transaction` (the model class) |
| `rebalance_scope_group!` | `ActiveRecord::Base.transaction` | `self.class.transaction` |
| `kanban_move` | `ActiveRecord::Base.transaction` | `record.class.transaction` |

Confirmed against the Rails source rather than inferred: `Transactions::ClassMethods#transaction` is `with_connection { |c| c.transaction(...) }` — the transaction opens on the *receiver's* pool — while `update_column → update_columns → self.class._update_record` sends the UPDATE on the *model's* pool.

Each site carries a comment explaining why, because the fixed code looks identical to the broken code to a casual reader.

### The kanban case is narrower than atomic, deliberately

`record.class` covers every write the action itself owns — the `on_exit`/`on_enter` saves, `reposition!` and any rebalance it triggers, the final save. None of those were protected before. But a drop interaction or a user-supplied `on_enter` can write arbitrary models, and those are covered only if they share the record's connection. Rails has no two-phase commit across pools, so a write to a model on a *third* database can't be rolled back by any single receiver. The comment says exactly this rather than implying a guarantee that doesn't exist.

## Test

`test/plutonium/positioning_secondary_database_test.rb` runs a model on a genuinely separate connection pool (asserted by a harness sanity test, so the atomicity checks can't pass vacuously).

It's **behavioural**, not an implementation assertion: it raises partway through a rebalance and asserts a full `pluck(:id, :position)` snapshot is unchanged. Nothing asserts which connection anything opened on, so it survives reshaping of the implementation that keeps the guarantee.

**Verified to fail without the fix** — three of ten rows renumbered and committed, unrecoverably:

```
-[[1, 1.0], [2, 1.00000001], [3, 30.0], [4, 40.0], ...]
+[[1, 1.0], [2, 2.0],        [3, 3.0],  [4, 40.0], ...]

4 runs, 7 assertions, 2 failures
```

With the fix: `4 runs, 7 assertions, 0 failures`.

The harness uses `establish_connection` with a config hash rather than a `database.yml` key, so it adds nothing to `test/dummy` (which the generator tests `git clean`).

## Not changed

The same `ActiveRecord::Base.transaction` pattern appears elsewhere. Assessed and deliberately left alone:

- **`wizard/runner.rb` (5 sites)** — different situation. These blocks contain zero framework-owned writes: `sync_data` is in-memory, `persist_state` runs outside, and the contents are user callbacks plus `destroy!` on records from arbitrary GlobalIDs. No receiver dominates, so `ActiveRecord::Base` is as good as anything.
- **`invites/controller.rb:140`** — genuinely two models (user + invite), so no dominant receiver, but the same latent exposure exists. A real decision, not a mechanical fix.
- **`saas/welcome` template** — entity, membership and profile are core tenancy models; nobody puts those on solid_queue's database.

## Verification

- `rails-8.1`: 2719 runs, 6717 assertions, 0 failures
- `standardrb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDJ4A3cWgH5H3EvYKStqPv