### PR TITLE
chore: prune the 0.49.0 notice from post_install_message

### DIFF
--- a/plutonium.gemspec
+++ b/plutonium.gemspec
@@ -23,24 +23,12 @@ Gem::Specification.new do |spec|
   # owner changes). `gem push` will prompt for an OTP at release time.
   spec.metadata["rubygems_mfa_required"] = "true"
 
+  # post_install_message prints on EVERY install, so it carries only notices
+  # that are still actionable for someone installing THIS version. The 0.49.0
+  # entity-scope rename was removed once it was ~14 releases old: anyone
+  # upgrading across it had long since done so, and anyone installing fresh
+  # was being handed history they had no way to act on.
   spec.post_install_message = <<~MSG
-    ℹ️  Plutonium — breaking change introduced in 0.49.0
-
-    Entity-scoped URL helpers and path params were renamed in 0.49.0 from
-    `<entity>_scope_*` to `<entity>_scoped_*`.
-
-    Examples:
-      organization_scope_widgets_path  →  organization_scoped_widgets_path
-      params[:organization_scope]      →  params[:organization_scoped]
-
-    If you are upgrading from 0.48.0 or earlier and reference these helpers or
-    params directly (e.g. in tests, custom redirects, or hand-written links),
-    update them to the new names.
-
-    Apps that only use `resource_url_for` are unaffected.
-
-    ────────────────────────────────────────────────────────────────
-
     ⚠️  Ruby 3.2 support ends in the NEXT release
 
     This is the last Plutonium release that installs on Ruby 3.2.

--- a/plutonium.gemspec
+++ b/plutonium.gemspec
@@ -23,11 +23,8 @@ Gem::Specification.new do |spec|
   # owner changes). `gem push` will prompt for an OTP at release time.
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  # post_install_message prints on EVERY install, so it carries only notices
-  # that are still actionable for someone installing THIS version. The 0.49.0
-  # entity-scope rename was removed once it was ~14 releases old: anyone
-  # upgrading across it had long since done so, and anyone installing fresh
-  # was being handed history they had no way to act on.
+  # Prints on EVERY install: only notices still actionable for someone
+  # installing THIS version.
   spec.post_install_message = <<~MSG
     ⚠️  Ruby 3.2 support ends in the NEXT release
 


### PR DESCRIPTION
`post_install_message` prints on **every** install, not only when someone upgrades across the version it describes. The entity-scope rename notice was still being shown at 0.62.2 — roughly fourteen releases after the change it warns about.

By now anyone upgrading across 0.49.0 has long since done so, and anyone installing fresh was being handed history with nothing to act on.

That matters more than it sounds: a message that is noise for almost every reader trains people to skip the block — which is precisely where the **Ruby 3.2 deprecation notice** now lives, and that one needs to be read before the next release removes 3.2.

## What stays

The 3.2 notice, unchanged. It is current, actionable, and time-limited. #79 removes it as part of actually dropping 3.2, at which point `post_install_message` is empty and the field goes with it.

## What's added

A comment stating the retention rule, so the next notice added here gets removed when it stops applying rather than accumulating:

> `post_install_message` prints on EVERY install, so it carries only notices that are still actionable for someone installing THIS version.

## Note on #79

#79 edits the same heredoc (it removes the 3.2 block). Whichever merges second will need a trivial conflict resolution in that one region — no logic to reconcile, just overlapping deletions. Happy to rebase #79 onto this once you've decided the order.

## Verification

- `standardrb` clean
- `Gem::Specification.load("plutonium.gemspec")` succeeds and `post_install_message` now opens on the Ruby 3.2 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDJ4A3cWgH5H3EvYKStqPv