### PR TITLE
fix(ui): honour `as: :hidden` when declared on input

### DIFF
--- a/lib/plutonium/ui/form/resource.rb
+++ b/lib/plutonium/ui/form/resource.rb
@@ -305,6 +305,14 @@ module Plutonium
           tag_block = input_definition[:block] || ->(f) { f.component_for(tag, **tag_attributes) }
 
           # Keep `:as` so the Builder can detect hidden fields via `options[:as]`.
+          # `as:` may be declared on either `field` or `input`, and the tag
+          # lookup above already honours both. Carry the resolved value back
+          # into field_options so the Builder sees it too: without this,
+          # `input :x, as: :hidden` renders a hidden input inside a fully
+          # chromed wrapper, label and all, while `field :x, as: :hidden`
+          # renders correctly. The Builder consumes `:as` before Phlexi sees
+          # the options, so this cannot leak into a Phlexi field option.
+          field_options = field_options.merge(as: tag) if tag
           field_options = field_options.except(:condition)
 
           condition = input_options[:condition] || field_options[:condition]

--- a/test/dummy/app/definitions/kitchen_sink_definition.rb
+++ b/test/dummy/app/definitions/kitchen_sink_definition.rb
@@ -71,6 +71,12 @@ class KitchenSinkDefinition < ::ResourceDefinition
 
   # Basic scalar inputs
   input :email_address, as: :email
+  # Declared with `as: :hidden` on `input` alone, with no companion
+  # `field` declaration. That is the spelling an author reaches for first,
+  # and it must produce the same hidden wrapper that `field :x, as: :hidden`
+  # does rather than a hidden input inside a labelled wrapper.
+  input :tracking_id, as: :hidden
+
   input :secret, as: :password
   # In the 2-column :appearance section, but opts back to full width via an
   # explicit col-span — which must survive the section's `columns:` default.

--- a/test/dummy/app/policies/kitchen_sink_policy.rb
+++ b/test/dummy/app/policies/kitchen_sink_policy.rb
@@ -17,7 +17,7 @@ class KitchenSinkPolicy < ::ResourcePolicy
   ATTRIBUTES = %i[
     name organization user email_address secret website favorite_color age
     balance price description bio active featured plan tier birthday meeting_at
-    alarm_time phone config prefs status secret_token
+    alarm_time phone config prefs status secret_token tracking_id
   ].freeze
 
   def permitted_attributes_for_create

--- a/test/dummy/db/migrate/20260802000000_add_tracking_id_to_kitchen_sinks.rb
+++ b/test/dummy/db/migrate/20260802000000_add_tracking_id_to_kitchen_sinks.rb
@@ -1,0 +1,5 @@
+class AddTrackingIdToKitchenSinks < ActiveRecord::Migration[[Rails::VERSION::MAJOR, Rails::VERSION::MINOR].join(".").to_f]
+  def change
+    add_column :kitchen_sinks, :tracking_id, :string, default: "trk_123"
+  end
+end

--- a/test/integration/admin_portal/form_layout_rendering_test.rb
+++ b/test/integration/admin_portal/form_layout_rendering_test.rb
@@ -23,6 +23,19 @@ class AdminPortal::FormLayoutRenderingTest < ActionDispatch::IntegrationTest
     assert_includes response.body, %(name="kitchen_sink[age]")
   end
 
+  # `as: :hidden` is honoured whether it is declared on `field` or on `input`.
+  # The tag lookup reads from either, and so does the wrapper selection, so an
+  # input-only declaration gets the same hidden wrapper rather than a hidden
+  # input inside a labelled wrapper that still occupies a grid cell.
+  test "a field declared hidden via input renders without label chrome" do
+    get "/admin/kitchen_sinks/new"
+    assert_response :success
+
+    assert_includes response.body, %(name="kitchen_sink[tracking_id]")
+    assert_match(/<div hidden>\s*<input[^>]*name="kitchen_sink\[tracking_id\]"/, response.body)
+    refute_match(/<label[^>]*for="[^"]*tracking_id[^"]*"/, response.body)
+  end
+
   test "collapsible section renders a details element" do
     get "/admin/kitchen_sinks/new"
     assert_match(/<details[^>]*\bopen\b/, response.body)


### PR DESCRIPTION
## The problem

`render_simple_resource_field` builds its two option hashes from different sources:

```ruby
field_options = definition.defined_fields[name] ? definition.defined_fields[name][:options] : {}
input_options = input_definition[:options] || {}

tag = input_options[:as] || field_options[:as]        # reads from either
...
render form.field(name, **field_options).wrapped(...)  # only ever field_options
```

`Builder#hidden?` checks the `:as` that reached `Builder.new`, which comes from `field_options`. So the two spellings diverge:

- `field :x, as: :hidden` renders through `HiddenWrapper` as intended.
- `input :x, as: :hidden` resolves the *tag* correctly, so you get an `<input type="hidden">`, but the wrapper never learns it is hidden. The field renders with its label, hint and error chrome, and still occupies a CSS Grid cell.

The second is the spelling most authors reach for first, since `input` is where every other input option goes.

## The fix

Carry the resolved tag back into `field_options` so the Builder sees it. `Builder#initialize` consumes `:as` before `super`, so it cannot leak into a Phlexi field option.

## Test

`test/integration/admin_portal/form_layout_rendering_test.rb` gains a case asserting the hidden wrapper for a field declared via `input` alone. The dummy app's only previous `as: :hidden` usage (`secret_token`) sits inside a section with `condition: -> { false }`, so it never rendered and the gap was never exercised. This adds `tracking_id`, declared with `input :tracking_id, as: :hidden` and rendered normally.

Verified by reverting the one-line change and confirming the new assertion fails:

```
Expected /<div hidden>\s*<input[^>]*name="kitchen_sink\[tracking_id\]"/ to match ...
```

Full suite on `rails-8.1`: 2716 tests, 6717 assertions, 0 failures, 0 errors.

## Found via

Building a `structured_input` repeater whose rows carry a hidden id. Worth noting the same asymmetry affects any resource form field, not just structured inputs.