### PR TITLE
feat(wizard): resolve a step's proc options against the wizard

### DIFF
--- a/.claude/skills/plutonium-wizard/SKILL.md
+++ b/.claude/skills/plutonium-wizard/SKILL.md
@@ -179,6 +179,29 @@ Repeater rows rehydrate from staged `data` on GET (resume / back re-renders fill
 
 Validations drive the form's field affordances just like a resource form: `presence` → the required marker (`*`); `length`/`numericality`/`format`/`inclusion` → `maxlength`/`min`/`max`/`pattern`/auto-choices. This holds for validations imported via `using:` too. (Structured-input sub-fields are the exception — they carry no validators, so no markers there.)
 
+### Options that depend on the run
+
+The step block runs **once, when the class loads**, so a literal option is frozen for every run. A **proc-valued** field/input option is resolved on **every render**, against the **wizard** — the same receiver a step's `condition:` gets, so `anchor`, `data`, `persisted` and `current_user` read as they do anywhere else in the wizard:
+
+```ruby
+step :plan do
+  attribute :tier
+  input :tier, as: :select, choices: -> { anchor.available_tiers }
+end
+```
+
+It is also how a custom component receives per-run configuration:
+
+```ruby
+input :answers, as: MyManifestComponent, config: -> { anchor.manifest }
+```
+
+Three limits worth knowing:
+
+- The **field set** is still fixed at class load — a proc varies an option, not which fields exist. To collect a shape known only at runtime, declare one `structured_input` and let a custom component render the inner controls.
+- A **step's** `condition:` runs against the wizard; a **field's** `condition:` runs against the form (`object` = that step's staged data). Only the field-level one is excluded from the resolution above.
+- **Only wizard steps resolve options this way.** On a resource or interaction form a proc option keeps its own binding — one declared in `customize_inputs` closes over the interaction, and a consumer that wants a callable calls it (Phlexi materialises `choices:` that way). A step block closes over a throwaway recorder, which is why the wizard resolves them itself.
+
 ## Attachment fields (file uploads)
 
 A step can collect a file. Declare it like any field — a **`:string`** attribute (it holds the upload **token**, not the bytes) + a file input:
@@ -277,6 +300,8 @@ end
 | `persisted[:step_key]` | Record(s) registered via `persist` in `on_submit`. Rehydrated on resume. |
 | `succeed(v)` / `failed(errs)` | Outcome helpers (alias `success`). `.with_message`, `.with_redirect_response` chainable. |
 | `fail!(msg)` / `fail!(:field, msg)` | Raise a `StepError` from `on_submit`/`execute`. |
+
+Available inside steps, `condition:`, `on_submit`, `on_rollback` and `execute` — and inside a step's **proc-valued field/input options**, which resolve against the wizard too (see **Step internals → Options that depend on the run**).
 
 ## Anchoring
 

--- a/docs/reference/wizard/dsl.md
+++ b/docs/reference/wizard/dsl.md
@@ -83,6 +83,32 @@ A step's block is the same field DSL used on definitions and interactions:
 
 See [plutonium-resource › Definition](/reference/resource/definition) for the full field/input/layout vocabulary.
 
+#### Runtime input options
+
+A step's fields are fixed when the class loads, so a **proc** is how an option depends on the run. Proc-valued field/input options are resolved on every render, **against the wizard** — the same receiver a step's `condition:` gets, so `anchor`, `data`, `persisted` and `current_user` read exactly as they do everywhere else in the wizard:
+
+```ruby
+step :plan do
+  attribute :tier
+  input :tier, as: :select, choices: -> { anchor.available_tiers }
+end
+```
+
+It is also how a custom component receives per-run configuration:
+
+```ruby
+input :answers, as: MyManifestComponent, config: -> { anchor.manifest }
+```
+
+Two limits worth knowing:
+
+- The **field set** is still fixed at class load. A proc varies an option, not which fields exist. To collect a shape known only at runtime, declare one `structured_input` and let a custom component render the inner controls.
+- `condition:` is **not** resolved this way. A *step's* `condition:` runs against the wizard; a *field's* `condition:` runs against the form, where `object` is that step's staged data.
+
+::: tip Only wizard steps do this
+On a resource or interaction form a proc option keeps its own binding: one declared in `customize_inputs` closes over the interaction, and a consumer that wants a callable calls it (Phlexi materialises `choices:` that way). A step block is `instance_exec`'d against a throwaway recorder, so it closes over nothing useful — hence the wizard resolves them itself.
+:::
+
 ### `using:` a model
 
 `using:` imports field declarations from an ActiveRecord model so a step needn't re-declare them. It is a **step option**, not a block method (avoids Ruby's `Module#using` refinements clash), and it targets a **model only**.
@@ -312,6 +338,8 @@ Available inside steps, `condition:`, `on_submit`, `on_rollback`, and `execute`:
 | `data.<step>.<field>` | The cast value (real Boolean/Integer/Date, not raw string). `data.<step>.<structured>` → array of typed sub-objects. An unknown step key reads as `nil`. |
 | `anchor` | The record the wizard was launched against. Raises `NotAnchoredError` if the wizard isn't `anchored`. |
 | `persisted[:step_key]` | Record(s) a per-step `on_submit` registered via `persist`. Lazily rehydrated on first access (located from stored GlobalIDs the first time you read the key, memoized thereafter). |
+
+A **proc-valued field/input option** on a step resolves against the wizard too, so the same accessors apply there — see [Runtime input options](#runtime-input-options).
 
 ## Outcome helpers
 

--- a/lib/plutonium/ui/form/resource.rb
+++ b/lib/plutonium/ui/form/resource.rb
@@ -289,6 +289,9 @@ module Plutonium
           input_definition = definition.defined_inputs[name] || {}
           input_options = input_definition[:options] || {}
 
+          field_options = resolve_option_procs(field_options)
+          input_options = resolve_option_procs(input_options)
+
           tag = input_options[:as] || field_options[:as]
 
           # Extract field-level options from input_options and merge into field_options
@@ -346,6 +349,21 @@ module Plutonium
             end
           end
         end
+
+        # Hook: a subclass may resolve proc-valued field/input options for this
+        # render. The base form deliberately passes them through.
+        #
+        # A proc option belongs to whatever owns the flow's data, and here that
+        # is already its own binding: an option declared in an interaction's
+        # `customize_inputs` closes over the interaction (`choices: -> {
+        # reviewer_choices }`), and a consumer that wants a callable calls it
+        # (Phlexi materialises `choices:` this way). Rebinding `self` here would
+        # break that.
+        #
+        # A wizard step is the exception, because its block is instance_exec'd
+        # against a throwaway recorder and so closes over nothing useful. See
+        # Form::Wizard.
+        def resolve_option_procs(options) = options
 
         def when_permitted(name, &)
           return unless resource_fields.include? name

--- a/lib/plutonium/ui/form/wizard.rb
+++ b/lib/plutonium/ui/form/wizard.rb
@@ -16,8 +16,13 @@ module Plutonium
         # @param action  [String] the current step's POST URL.
         # @param fields  [Array<Symbol>] the step's renderable field names
         #   (scalar attributes + structured inputs).
-        def initialize(step:, data:, action:, fields:, **options, &)
+        # @param wizard  [Plutonium::Wizard::Base, nil] the run being rendered,
+        #   used to resolve a step's proc-valued options against. Optional so an
+        #   existing caller keeps working; without it those options pass through
+        #   unresolved, as they do on every other form.
+        def initialize(step:, data:, action:, fields:, wizard: nil, **options, &)
           @step = step
+          @wizard = wizard
           options[:key] = :wizard
           options[:as] = :wizard
           options[:action] = action
@@ -29,7 +34,29 @@ module Plutonium
 
         private
 
-        attr_reader :step
+        attr_reader :step, :wizard
+
+        # A step block is instance_exec'd against a FieldCapture when the wizard
+        # class loads, so a proc declared there closes over a recorder that holds
+        # nothing. Resolve it against the wizard instead, which is where the rest
+        # of the wizard DSL already points:
+        #
+        #   input :tier, as: :select, choices: -> { anchor.available_tiers }
+        #
+        # Same receiver a step's `condition:` gets (see Wizard::Runner), so
+        # `anchor`, `data`, `persisted` and `current_user` read the same in an
+        # option as they do everywhere else in the wizard.
+        #
+        # `condition:` is excluded here. A FIELD's condition is evaluated against
+        # the form, where `object` is this step's staged data; only a STEP's
+        # condition belongs to the wizard.
+        def resolve_option_procs(options)
+          return options if options.blank? || wizard.nil?
+
+          options.to_h do |key, value|
+            [key, (key != :condition && value.is_a?(Proc)) ? wizard.instance_exec(&value) : value]
+          end
+        end
 
         def form_template
           # The direction defaults to "next"; the nav buttons in the page override

--- a/lib/plutonium/ui/page/wizard.rb
+++ b/lib/plutonium/ui/page/wizard.rb
@@ -128,6 +128,7 @@ module Plutonium
               render_step_header(step)
               render Plutonium::UI::Form::Wizard.new(
                 step:,
+                wizard: @runner.wizard,
                 # Decorate so attachment fields read as resolved attachments (the
                 # Uppy preview rehydrates on Back/resume); other fields pass through.
                 data: Plutonium::Wizard::AttachmentData.wrap(@runner.wizard.data[step.key], step),

--- a/lib/plutonium/wizard/driving.rb
+++ b/lib/plutonium/wizard/driving.rb
@@ -528,6 +528,7 @@ module Plutonium
         step = runner.current_step
         Plutonium::UI::Form::Wizard.new(
           step:,
+          wizard: runner.wizard,
           data: Plutonium::Wizard::AttachmentData.wrap(runner.wizard.data[step.key], step),
           action: wizard_step_url(step&.key),
           fields: step.attribute_schema.keys.map(&:to_sym) + step.structured_inputs.keys.map(&:to_sym)

--- a/test/dummy/app/wizards/configure_widget_wizard.rb
+++ b/test/dummy/app/wizards/configure_widget_wizard.rb
@@ -12,7 +12,9 @@ class ConfigureWidgetWizard < Plutonium::Wizard::Base
 
   step :rename do
     attribute :name, :string
-    input :name
+    # A proc-valued input option resolves against the wizard on every render, so
+    # `anchor` reads here exactly as it does in `condition:` or `execute`.
+    input :name, placeholder: -> { "Currently #{anchor.name}" }
     validates :name, presence: true
   end
 

--- a/test/integration/org_portal/anchored_wizard_test.rb
+++ b/test/integration/org_portal/anchored_wizard_test.rb
@@ -44,6 +44,30 @@ class OrgPortal::AnchoredWizardTest < ActionDispatch::IntegrationTest
     assert_equal "#{base}/rename", URI(response.location).path
   end
 
+  # A step's fields are fixed when the class loads, so a proc is how an option
+  # depends on the run. It resolves against the wizard, the same receiver a
+  # step's `condition:` gets, so `anchor` reads the same in both.
+  test "a proc-valued input option resolves against the wizard" do
+    get "#{base}/rename"
+
+    assert_response :success
+    assert_includes response.body, "Currently #{@widget.name}"
+  end
+
+  test "the option follows the anchor, not a value captured at class load" do
+    @widget.update!(name: "Renamed since boot")
+
+    get "#{base}/rename"
+
+    assert_includes response.body, "Currently Renamed since boot"
+  end
+
+  test "the anchor a proc option sees is the scoped one, not another tenant's" do
+    get "#{prefix}/widgets/#{@other_widget.id}/wizards/configure/rename"
+
+    assert_response :not_found
+  end
+
   test "implicitly keyed by [widget, user]: a second launch resumes, not forks" do
     post "#{base}/rename", params: {wizard: {name: "Draft"}, _direction: "next"}
     assert_equal 1, Plutonium::Wizard::Session.where(status: "in_progress").count


### PR DESCRIPTION
A step block is `instance_exec`'d against a `FieldCapture` when the wizard class
loads, so a proc declared there closes over a recorder that holds nothing. That
left proc-valued field/input options with no useful binding, and no way for an
option to depend on the run being rendered.

They now resolve **against the wizard**, the same receiver a step's `condition:`
already gets (`Wizard::Runner` does `@wizard.instance_exec(&step.condition)`), so
`anchor`, `data`, `persisted` and `current_user` read in an option exactly as they
do everywhere else in the wizard DSL:

```ruby
step :plan do
  attribute :tier
  input :tier, as: :select, choices: -> { anchor.available_tiers }
end
```

It is also how a custom component gets per-run configuration, which is what
prompted this:

```ruby
input :answers, as: MyManifestComponent, config: -> { anchor.manifest }
```

### Why only wizard steps

Everywhere else a proc option already belongs to whatever owns the flow's data.
An option declared in an interaction's `customize_inputs` closes over the
interaction (`choices: -> { reviewer_choices }`), and a consumer that wants a
callable calls it — Phlexi materialises `choices:` this way in
`simple_choices_mapper.rb`. Rebinding those would break them, which the suite
demonstrated when an earlier revision of this branch tried it.

So `Form::Resource` keeps a documented pass-through and only `Form::Wizard`
resolves. The rule is consistent rather than a carve-out: a proc resolves against
the object that owns the flow's data, and a step block is the one place that
object isn't already its binding.

### Scope

- The **field set** is still fixed at class load. This varies an option, not
  which fields exist.
- A **step's** `condition:` runs against the wizard; a **field's** `condition:`
  runs against the form, where `object` is that step's staged data. Only the
  field-level one is excluded here, and that is pre-existing behaviour.
- The `wizard:` keyword on `Form::Wizard` is optional, so an external caller
  keeps working; without it options pass through as before.

### Tests

`ConfigureWidgetWizard` uses `placeholder: -> { "Currently #{anchor.name}" }`,
covered by three integration tests: that it renders, that it follows the anchor
rather than a value captured at class load, and that another tenant's widget
still 404s so the anchor stays the scoped, policy-gated record.

### Note on CI

`test/plutonium/resource/controller_test.rb` has 5 errors (`undefined method
path_parameters` in `current_nested_route_config`). They reproduce on plain
`origin/master` without this branch, so they arrived with aadc32c2 and are not
from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)