### PR TITLE
feat(ui): resolve proc-valued input options on every form

### DIFF
--- a/.claude/skills/plutonium-resource/SKILL.md
+++ b/.claude/skills/plutonium-resource/SKILL.md
@@ -602,6 +602,21 @@ field :debug_info, condition: -> { Rails.env.development? }
 
 Use `condition` for UI state; use the policy for authorization.
 
+## Options That Vary Per Render
+
+Any field/input option may be a **proc**, resolved on every render rather than frozen at class load. Arity picks what it receives:
+
+```ruby
+input :tier,  as: :select, choices: ->(form) { form.object.account.available_tiers }
+input :notes, placeholder: -> { "Updated #{Time.current.year}" }
+```
+
+- `->(form) { … }` gets the form — `object` (the record), `params`, view helpers.
+- `-> { … }` is called as-is, keeping its own binding. That is what makes `choices: -> { reviewer_choices }` work inside an interaction's `customize_inputs`, where the proc closes over the interaction.
+- `condition:` is the exception — evaluated separately at render, always against the form.
+
+A wizard step resolves a zero-arity proc against the **wizard** instead (its block closes over a throwaway recorder). See [[plutonium-wizard]].
+
 ## Dynamic Forms (`pre_submit`)
 
 A `pre_submit: true` field triggers a server re-render on change, re-evaluating `condition:` procs. Use for cascading or context-dependent forms.

--- a/.claude/skills/plutonium-wizard/SKILL.md
+++ b/.claude/skills/plutonium-wizard/SKILL.md
@@ -179,6 +179,31 @@ Repeater rows rehydrate from staged `data` on GET (resume / back re-renders fill
 
 Validations drive the form's field affordances just like a resource form: `presence` → the required marker (`*`); `length`/`numericality`/`format`/`inclusion` → `maxlength`/`min`/`max`/`pattern`/auto-choices. This holds for validations imported via `using:` too. (Structured-input sub-fields are the exception — they carry no validators, so no markers there.)
 
+### Options that depend on the run
+
+The step block runs **once, when the class loads**, so a literal option is frozen for every run. A **proc-valued** field/input option is resolved on **every render**, against the **wizard** — the same receiver a step's `condition:` gets, so `anchor`, `data`, `persisted` and `current_user` read as they do anywhere else in the wizard:
+
+```ruby
+step :plan do
+  attribute :tier
+  input :tier, as: :select, choices: -> { anchor.available_tiers }
+end
+```
+
+It is also how a custom component receives per-run configuration:
+
+```ruby
+input :answers, as: MyManifestComponent, config: -> { anchor.manifest }
+```
+
+A one-argument proc still takes the form, as on any other form, for `object` (this step's staged data), `params` and helpers: `choices: ->(form) { form.object.region_tiers }`.
+
+Three limits worth knowing:
+
+- The **field set** is still fixed at class load — a proc varies an option, not which fields exist. To collect a shape known only at runtime, declare one `structured_input` and let a custom component render the inner controls. For bespoke markup pass a **block** to `input` instead; it renders in the form's context with the field yielded.
+- A **step's** `condition:` runs against the wizard; a **field's** `condition:` runs against the form (`object` = that step's staged data). Only the field-level one is excluded from the resolution above.
+- **Proc options resolve on every form** ([[plutonium-resource]]); only the zero-arity receiver differs here. Elsewhere a zero-arity proc keeps its own binding, because that binding is already useful — one declared in `customize_inputs` closes over the interaction. A step block closes over a throwaway recorder, so the wizard takes its place.
+
 ## Attachment fields (file uploads)
 
 A step can collect a file. Declare it like any field — a **`:string`** attribute (it holds the upload **token**, not the bytes) + a file input:
@@ -277,6 +302,8 @@ end
 | `persisted[:step_key]` | Record(s) registered via `persist` in `on_submit`. Rehydrated on resume. |
 | `succeed(v)` / `failed(errs)` | Outcome helpers (alias `success`). `.with_message`, `.with_redirect_response` chainable. |
 | `fail!(msg)` / `fail!(:field, msg)` | Raise a `StepError` from `on_submit`/`execute`. |
+
+Available inside steps, `condition:`, `on_submit`, `on_rollback` and `execute` — and inside a step's **proc-valued field/input options**, which resolve against the wizard too (see **Step internals → Options that depend on the run**).
 
 ## Anchoring
 

--- a/docs/reference/resource/definition.md
+++ b/docs/reference/resource/definition.md
@@ -200,6 +200,22 @@ field   :debug_info,       condition: -> { Rails.env.development? }
 `condition:` is for UI logic ("show this when published"). For "who can see this", use the policy's `permitted_attributes_for_*` — see [Behavior › Policy](/reference/behavior/policies).
 :::
 
+## Options that vary per render
+
+Any field/input option may be a **proc**, resolved on every render rather than frozen when the class loads. Arity picks what it receives:
+
+```ruby
+input :tier,  as: :select, choices: ->(form) { form.object.account.available_tiers }
+input :notes, placeholder: -> { "Updated #{Time.current.year}" }
+```
+
+- **`->(form) { … }`** is handed the form, so `object` (the record being edited), `params` and view helpers are all reachable.
+- **`-> { … }`** is called as-is, keeping whatever it closed over. That matters for an option declared inside an interaction's `customize_inputs`, which closes over the interaction: `choices: -> { reviewer_choices }` resolves against it.
+
+`condition:` is the exception — it is evaluated separately at render (above), always against the form.
+
+A wizard step resolves a zero-arity proc against the **wizard** instead, since a step block closes over a throwaway recorder rather than anything useful. See [Wizard DSL › Runtime input options](/reference/wizard/dsl#runtime-input-options).
+
 ## Dynamic forms (`pre_submit`)
 
 A field with `pre_submit: true` triggers a server re-render on change, re-evaluating `condition:` procs. Use for cascading or context-dependent forms.

--- a/docs/reference/wizard/dsl.md
+++ b/docs/reference/wizard/dsl.md
@@ -83,6 +83,38 @@ A step's block is the same field DSL used on definitions and interactions:
 
 See [plutonium-resource › Definition](/reference/resource/definition) for the full field/input/layout vocabulary.
 
+#### Runtime input options
+
+A step's fields are fixed when the class loads, so a **proc** is how an option depends on the run. Proc-valued field/input options are resolved on every render, **against the wizard** — the same receiver a step's `condition:` gets, so `anchor`, `data`, `persisted` and `current_user` read exactly as they do everywhere else in the wizard:
+
+```ruby
+step :plan do
+  attribute :tier
+  input :tier, as: :select, choices: -> { anchor.available_tiers }
+end
+```
+
+It is also how a custom component receives per-run configuration:
+
+```ruby
+input :answers, as: MyManifestComponent, config: -> { anchor.manifest }
+```
+
+A one-argument proc still takes the form, as on any other form, for `object` (this step's staged data), `params` and helpers:
+
+```ruby
+input :tier, as: :select, choices: ->(form) { form.object.region_tiers }
+```
+
+Two limits worth knowing:
+
+- The **field set** is still fixed at class load. A proc varies an option, not which fields exist. To collect a shape known only at runtime, declare one `structured_input` and let a custom component render the inner controls. For bespoke markup, pass a block to `input` instead — it renders in the form's context with the field yielded.
+- `condition:` is **not** resolved this way. A *step's* `condition:` runs against the wizard; a *field's* `condition:` runs against the form, where `object` is that step's staged data.
+
+::: tip What differs from other forms
+Proc options resolve on **every** form (see [Definition › inputs](/reference/resource/definition)); only the zero-arity receiver differs. Elsewhere a zero-arity proc keeps its own binding, because that binding is already useful — one declared in an interaction's `customize_inputs` closes over the interaction. A step block is `instance_exec`'d against a throwaway recorder, so there is no binding worth keeping and the wizard takes its place.
+:::
+
 ### `using:` a model
 
 `using:` imports field declarations from an ActiveRecord model so a step needn't re-declare them. It is a **step option**, not a block method (avoids Ruby's `Module#using` refinements clash), and it targets a **model only**.
@@ -312,6 +344,8 @@ Available inside steps, `condition:`, `on_submit`, `on_rollback`, and `execute`:
 | `data.<step>.<field>` | The cast value (real Boolean/Integer/Date, not raw string). `data.<step>.<structured>` → array of typed sub-objects. An unknown step key reads as `nil`. |
 | `anchor` | The record the wizard was launched against. Raises `NotAnchoredError` if the wizard isn't `anchored`. |
 | `persisted[:step_key]` | Record(s) a per-step `on_submit` registered via `persist`. Lazily rehydrated on first access (located from stored GlobalIDs the first time you read the key, memoized thereafter). |
+
+A **proc-valued field/input option** on a step resolves against the wizard too, so the same accessors apply there — see [Runtime input options](#runtime-input-options).
 
 ## Outcome helpers
 

--- a/lib/plutonium/ui/form/resource.rb
+++ b/lib/plutonium/ui/form/resource.rb
@@ -289,6 +289,9 @@ module Plutonium
           input_definition = definition.defined_inputs[name] || {}
           input_options = input_definition[:options] || {}
 
+          field_options = resolve_option_procs(field_options)
+          input_options = resolve_option_procs(input_options)
+
           tag = input_options[:as] || field_options[:as]
 
           # Extract field-level options from input_options and merge into field_options
@@ -346,6 +349,37 @@ module Plutonium
             end
           end
         end
+
+        # Resolve proc-valued field/input options for THIS render, so any option
+        # can vary per request rather than being frozen when the class loads.
+        #
+        # Arity decides the receiver, matching what Phlexi already does for
+        # validators:
+        #
+        #   -> { … }       called as-is, keeping its own binding
+        #   ->(form) { … } called with this form, for `object`/`params`/helpers
+        #
+        # The binding is kept rather than rebound because on these forms it is
+        # already the useful one: an option declared in an interaction's
+        # `customize_inputs` closes over the interaction (`choices: -> {
+        # reviewer_choices }`), and `instance_exec` would throw that away. A
+        # closure can be handed context as an argument; context cannot recover a
+        # closure. Form::Wizard overrides this, because a step block closes over
+        # a throwaway recorder and so has no binding worth keeping.
+        #
+        # `condition:` is excluded: it is evaluated separately at render, and
+        # resolving it here would collapse it to a boolean first.
+        def resolve_option_procs(options)
+          return options if options.blank?
+
+          options.to_h do |key, value|
+            [key, resolvable_proc?(key, value) ? call_option_proc(value) : value]
+          end
+        end
+
+        def resolvable_proc?(key, value) = key != :condition && value.is_a?(Proc)
+
+        def call_option_proc(value) = value.arity.zero? ? value.call : value.call(self)
 
         def when_permitted(name, &)
           return unless resource_fields.include? name

--- a/lib/plutonium/ui/form/wizard.rb
+++ b/lib/plutonium/ui/form/wizard.rb
@@ -16,8 +16,13 @@ module Plutonium
         # @param action  [String] the current step's POST URL.
         # @param fields  [Array<Symbol>] the step's renderable field names
         #   (scalar attributes + structured inputs).
-        def initialize(step:, data:, action:, fields:, **options, &)
+        # @param wizard  [Plutonium::Wizard::Base, nil] the run being rendered,
+        #   used to resolve a step's proc-valued options against. Optional so an
+        #   existing caller keeps working; without it those options pass through
+        #   unresolved, as they do on every other form.
+        def initialize(step:, data:, action:, fields:, wizard: nil, **options, &)
           @step = step
+          @wizard = wizard
           options[:key] = :wizard
           options[:as] = :wizard
           options[:action] = action
@@ -29,7 +34,28 @@ module Plutonium
 
         private
 
-        attr_reader :step
+        attr_reader :step, :wizard
+
+        # Same arity rule as every other form; only the zero-arity receiver
+        # differs. A step block is instance_exec'd against a FieldCapture when
+        # the wizard class loads, so a proc declared there closes over a recorder
+        # that holds nothing. There is no binding worth keeping, so it runs
+        # against the wizard instead — where the rest of the wizard DSL already
+        # points:
+        #
+        #   input :tier, as: :select, choices: -> { anchor.available_tiers }
+        #
+        # That is the receiver a step's `condition:` already gets (see
+        # Wizard::Runner), so `anchor`, `data`, `persisted` and `current_user`
+        # read the same in an option as they do anywhere else in the wizard.
+        #
+        # ->(form) { … } still takes the form, as it does elsewhere, for
+        # `object` (this step's staged data), `params` and helpers.
+        def call_option_proc(value)
+          return super unless value.arity.zero? && wizard
+
+          wizard.instance_exec(&value)
+        end
 
         def form_template
           # The direction defaults to "next"; the nav buttons in the page override

--- a/lib/plutonium/ui/page/wizard.rb
+++ b/lib/plutonium/ui/page/wizard.rb
@@ -128,6 +128,7 @@ module Plutonium
               render_step_header(step)
               render Plutonium::UI::Form::Wizard.new(
                 step:,
+                wizard: @runner.wizard,
                 # Decorate so attachment fields read as resolved attachments (the
                 # Uppy preview rehydrates on Back/resume); other fields pass through.
                 data: Plutonium::Wizard::AttachmentData.wrap(@runner.wizard.data[step.key], step),

--- a/lib/plutonium/wizard/driving.rb
+++ b/lib/plutonium/wizard/driving.rb
@@ -528,6 +528,7 @@ module Plutonium
         step = runner.current_step
         Plutonium::UI::Form::Wizard.new(
           step:,
+          wizard: runner.wizard,
           data: Plutonium::Wizard::AttachmentData.wrap(runner.wizard.data[step.key], step),
           action: wizard_step_url(step&.key),
           fields: step.attribute_schema.keys.map(&:to_sym) + step.structured_inputs.keys.map(&:to_sym)

--- a/test/dummy/app/wizards/configure_widget_wizard.rb
+++ b/test/dummy/app/wizards/configure_widget_wizard.rb
@@ -12,8 +12,15 @@ class ConfigureWidgetWizard < Plutonium::Wizard::Base
 
   step :rename do
     attribute :name, :string
-    input :name
+    # A proc-valued input option resolves against the wizard on every render, so
+    # `anchor` reads here exactly as it does in `condition:` or `execute`.
+    input :name, placeholder: -> { "Currently #{anchor.name}" }
     validates :name, presence: true
+
+    # The case that motivated it: choices drawn from the anchor. Left optional so
+    # the other tests can post this step without supplying it.
+    attribute :rename_reason, :string
+    input :rename_reason, as: :select, choices: -> { ["#{anchor.name} was wrong", "Other"] }
   end
 
   review label: "Review"

--- a/test/integration/admin_portal/proc_input_options_test.rb
+++ b/test/integration/admin_portal/proc_input_options_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A field/input option may be a proc, resolved on every render so it can vary per
+# request instead of being frozen when the definition class loads.
+#
+# Arity picks the receiver, matching what Phlexi already does for validators:
+# a zero-arity proc keeps its own binding, and a one-argument proc is handed the
+# form (for `object`, `params`, helpers). This holds on every form; only the
+# wizard's zero-arity receiver differs, since a step block closes over a
+# throwaway recorder rather than anything useful.
+class AdminPortal::ProcInputOptionsTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+
+  setup do
+    login_as_admin(create_admin!)
+    @sink = KitchenSink.create!(name: "Original", organization: create_organization!)
+  end
+
+  teardown { KitchenSinkDefinition.instance_variable_set(:@merged_defined_inputs, nil) }
+
+  def redefine_input(**options)
+    KitchenSinkDefinition.input(:name, **options)
+    KitchenSinkDefinition.instance_variable_set(:@merged_defined_inputs, nil)
+  end
+
+  test "a zero-arity proc option is called and its value rendered" do
+    redefine_input(placeholder: -> { "from a proc" })
+
+    get "/admin/kitchen_sinks/#{@sink.id}/edit"
+
+    assert_response :success
+    assert_includes response.body, "from a proc"
+    refute_includes response.body, "#<Proc"
+  end
+
+  test "a one-argument proc option receives the form, so it can read the record" do
+    redefine_input(placeholder: ->(form) { "editing #{form.object.name}" })
+
+    get "/admin/kitchen_sinks/#{@sink.id}/edit"
+
+    assert_response :success
+    assert_includes response.body, "editing Original"
+  end
+
+  test "the option is resolved per render, not captured once" do
+    redefine_input(placeholder: ->(form) { "editing #{form.object.name}" })
+
+    get "/admin/kitchen_sinks/#{@sink.id}/edit"
+    @sink.update!(name: "Renamed")
+    get "/admin/kitchen_sinks/#{@sink.id}/edit"
+
+    assert_includes response.body, "editing Renamed"
+  end
+
+  # Rebinding would break an option declared in an interaction's
+  # `customize_inputs`, which closes over the interaction.
+  test "a zero-arity proc keeps its own binding" do
+    owner = Object.new
+    def owner.label = "from the closure"
+    redefine_input(placeholder: -> { owner.label })
+
+    get "/admin/kitchen_sinks/#{@sink.id}/edit"
+
+    assert_includes response.body, "from the closure"
+  end
+end

--- a/test/integration/org_portal/anchored_wizard_test.rb
+++ b/test/integration/org_portal/anchored_wizard_test.rb
@@ -44,6 +44,40 @@ class OrgPortal::AnchoredWizardTest < ActionDispatch::IntegrationTest
     assert_equal "#{base}/rename", URI(response.location).path
   end
 
+  # A step's fields are fixed when the class loads, so a proc is how an option
+  # depends on the run. It resolves against the wizard, the same receiver a
+  # step's `condition:` gets, so `anchor` reads the same in both.
+  test "a proc-valued input option resolves against the wizard" do
+    get "#{base}/rename"
+
+    assert_response :success
+    assert_includes response.body, "Currently #{@widget.name}"
+  end
+
+  test "the option follows the anchor, not a value captured at class load" do
+    @widget.update!(name: "Renamed since boot")
+
+    get "#{base}/rename"
+
+    assert_includes response.body, "Currently Renamed since boot"
+  end
+
+  # The motivating case: without this a step's `choices:` proc is called with a
+  # FieldCapture as `self`, so reading `anchor` raises a NameError naming an
+  # internal the author never wrote.
+  test "choices drawn from the anchor materialise into options" do
+    get "#{base}/rename"
+
+    assert_response :success
+    assert_includes response.body, "#{@widget.name} was wrong"
+  end
+
+  test "the anchor a proc option sees is the scoped one, not another tenant's" do
+    get "#{prefix}/widgets/#{@other_widget.id}/wizards/configure/rename"
+
+    assert_response :not_found
+  end
+
   test "implicitly keyed by [widget, user]: a second launch resumes, not forks" do
     post "#{base}/rename", params: {wizard: {name: "Draft"}, _direction: "next"}
     assert_equal 1, Plutonium::Wizard::Session.where(status: "in_progress").count


### PR DESCRIPTION
A field/input option could not vary per render. Anything other than `condition:`
was handed to the tag as-is, so a proc reached Phlex and raised `Invalid
attribute value for placeholder: #<Proc…>`. The one exception was `choices:`,
which worked by accident of Phlexi materialising a callable collection.

Options are now resolved on **every** form, with arity picking the receiver —
the rule Phlexi already uses for validators (`options/validators.rb:16`):

```ruby
input :tier,  as: :select, choices: ->(form) { form.object.account.available_tiers }
input :notes, placeholder: -> { "Updated #{Time.current.year}" }
```

- `->(form) { … }` is handed the form: `object`, `params`, view helpers.
- `-> { … }` is called as-is, keeping its own binding.

### Why keep the binding instead of `instance_exec`

On a resource or interaction form the binding is already the useful one. An
option declared in an interaction's `customize_inputs` closes over the
interaction, so `choices: -> { reviewer_choices }` resolves against it.
`instance_exec` would throw that away — an earlier revision of this branch did
exactly that and the suite went red with `undefined local variable
reviewer_choices`.

A closure can always be handed context as an argument. Context can never recover
a lost closure. So the lossless direction wins, and `->(form)` covers what
rebinding would have offered.

### The wizard exception, and what started this

A step block is `instance_exec`'d against a `FieldCapture` when the class loads,
so a proc declared there closes over a recorder that holds nothing:

```ruby
step :plan do
  input :tier, as: :select, choices: -> { anchor.available_tiers }
end
```

```
NameError: undefined local variable or method `anchor'
  for an instance of Plutonium::Wizard::FieldCapture
```

An error naming an internal the author never wrote, for the most natural way to
vary a select, against an accessors table that promises `anchor` "inside steps".

A zero-arity proc on a step therefore resolves against the **wizard** — the
receiver a step's `condition:` already gets (`Wizard::Runner` does
`@wizard.instance_exec(&step.condition)`) — so `anchor`, `data`, `persisted` and
`current_user` read in an option exactly as they do elsewhere in the wizard DSL.
One-argument procs still take the form, as everywhere else. Only the zero-arity
receiver differs, and only because a step block has no binding worth keeping.

### Scope

- **Custom rendering is unaffected and unchanged.** An `input` block already
  renders in the form's context with the field yielded, and remains the right
  tool for bespoke markup. This is about ordinary options.
- The **field set** is still fixed at class load. This varies an option, not
  which fields exist.
- `condition:` stays excluded — evaluated separately at render. A *step's*
  `condition:` runs against the wizard; a *field's* runs against the form.
- The `wizard:` keyword on `Form::Wizard` is optional, so an external caller
  keeps working.

### Tests

- `test/integration/admin_portal/proc_input_options_test.rb` — a resource form
  resolves a zero-arity proc, passes the form to a one-argument proc, re-resolves
  per render rather than caching, and preserves a zero-arity proc's own binding.
- `test/integration/org_portal/anchored_wizard_test.rb` — a step's `choices:`
  drawn from the anchor materialises, the placeholder follows the anchor rather
  than a class-load value, and another tenant's record still 404s.

Docs and skills updated for both `plutonium-resource` and `plutonium-wizard`.

### Note on CI

`test/plutonium/resource/controller_test.rb` has 5 errors (`undefined method
path_parameters`). They are pre-existing on `origin/master` and fixed separately
in #88.

Supersedes #86, which GitHub auto-closed when the branch was renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)