### PR TITLE
fix: decide wizard finalize after staging the submission

### DIFF
--- a/.claude/skills/plutonium-behavior/SKILL.md
+++ b/.claude/skills/plutonium-behavior/SKILL.md
@@ -279,9 +279,11 @@ end
 | Method | Returns |
 |---|---|
 | `current_parent` | Parent record |
+| `current_parent_class` | `User` |
 | `current_nested_association` | `:posts` |
-| `parent_route_param` | `:user_id` |
 | `parent_input_param` | `:user` |
+
+The parent class and association come from the **route** (each nested route carries its registration key), not from parsing the URL. There is no `parent_route_param`.
 
 Parent fields are excluded from forms/displays by default — toggle with the presentation hooks above. For `has_one` associations, routes are singular (no `:id`); index redirects to show (or new if no record exists). See [[plutonium-tenancy]] for the full nested-routing story.
 

--- a/.claude/skills/plutonium-resource/SKILL.md
+++ b/.claude/skills/plutonium-resource/SKILL.md
@@ -604,18 +604,27 @@ Use `condition` for UI state; use the policy for authorization.
 
 ## Options That Vary Per Render
 
-Any field/input option may be a **proc**, resolved on every render rather than frozen at class load. Arity picks what it receives:
+Any option may be a **proc**, resolved on every render rather than frozen at class load. Holds across the whole form DSL — `field`, `input`, `section`/`ungrouped`, `structured_input`, nested inputs. Arity says **whether you want the form**:
 
 ```ruby
 input :tier,  as: :select, choices: ->(form) { form.object.account.available_tiers }
 input :notes, placeholder: -> { "Updated #{Time.current.year}" }
 ```
 
+- `-> { … }` is called as-is, keeping its own binding — it means what it reads like where you wrote it; nothing rebinds `self`. That is what makes `choices: -> { reviewer_choices }` work inside an interaction's `customize_inputs` (private helpers included).
 - `->(form) { … }` gets the form — `object` (the record), `params`, view helpers.
-- `-> { … }` is called as-is, keeping its own binding. That is what makes `choices: -> { reviewer_choices }` work inside an interaction's `customize_inputs`, where the proc closes over the interaction.
-- `condition:` is the exception — evaluated separately at render, always against the form.
 
-A wizard step resolves a zero-arity proc against the **wizard** instead (its block closes over a throwaway recorder). See [[plutonium-wizard]].
+Same rule on wizard steps — but a step block closes over an internal field recorder, so options there must take the form: `->(form) { form.wizard.anchor.tiers }`. See [[plutonium-wizard]].
+
+**`condition:` is not an option — it follows a different rule, for a reason.** An option asks "what value should this have?", so it may not care about the render and defaults to meaning what it reads like. `condition:` asks "should this render *here, now*?" — a question about the render context by definition. So it always runs **against** that context and reads it with no argument, where "context" is whatever is rendering:
+
+```ruby
+input   :notes,     condition: -> { object.published? }        # the form
+display :audit_log, condition: -> { current_user.admin? }      # the display component
+step    :billing,   condition: -> { data.plan.tier == "pro" }  # the wizard — no form exists yet
+```
+
+It cannot take a `form` argument the way an option does: for a `column`/`display`, a step, or an action there is no form.
 
 ## Dynamic Forms (`pre_submit`)
 
@@ -906,7 +915,7 @@ class PostDefinition < ResourceDefinition
   form_layout do
     section :identity, :name, :email, label: "Identity", description: "Who this is"
     section :address, :street, :city,
-      collapsible: true, collapsed: -> { object.persisted? }, columns: 2,
+      collapsible: true, collapsed: ->(form) { form.object.persisted? }, columns: 2,
       condition: -> { object.requires_address? }   # hide the whole section as a unit
     ungrouped label: "Other"                        # bucket for unlisted fields; position = where it renders
   end
@@ -914,7 +923,8 @@ end
 ```
 
 - **Layout references field KEYS only** — all per-field config (`as:`, `hint:`, blocks, per-field `condition:`) stays on `input`. Never duplicated here.
-- **Options**: `label:`, `description:`, `collapsible:`, `collapsed:`, `columns:` (positive Integer, literal only), `condition:`. Every option except `columns:` may be a **proc** resolved at render in the form context (`object`, `current_user`, `params`, helpers).
+- **Options**: `label:`, `description:`, `collapsible:`, `collapsed:`, `columns:` (positive Integer, literal only), `condition:`. Every option except `columns:` may be a **proc**, resolved at render under the same arity rule as any other option — take a `form` argument to read the render context.
+- ⚠️ **Breaking in 0.63**: section options used to take a zero-arg proc run *against* the form. They now follow the shared rule, and a `form_layout` block is evaluated against the layout builder, so a bare `object` is a `NameError`. Migrate `collapsed: -> { object.persisted? }` → `collapsed: ->(form) { form.object.persisted? }`. `condition:` is unchanged (still form-evaluated, still reads `object` with no argument).
 - **Absent fields are skipped.** A key the section lists that isn't in the permitted set (policy, per-action, scoping, nesting, or a typo) is silently dropped — never an error. The same layout serves a richly-permitted `edit` and a minimal `new`.
 - **🚨 Zero-field sections drop entirely** — no heading, no grid. So `+ New` (fewer permitted attributes) won't sprout empty headings. This checks *field presence only*; per-field `condition:` runs later, so to hide a whole section by state, gate it with the **section's own `condition:`**, not by hiding every field inside it.
 - **Works on interactions too** (`Plutonium::Interaction::Base`) — groups `attribute` declarations. There `object` is the interaction instance; for record actions the record is `object.resource`.

--- a/.claude/skills/plutonium-tenancy/SKILL.md
+++ b/.claude/skills/plutonium-tenancy/SKILL.md
@@ -338,10 +338,12 @@ You don't need to add hidden parent fields in forms or filter queries manually.
 
 ```ruby
 current_parent              # Parent record
+current_parent_class        # Company
 current_nested_association  # :properties
-parent_route_param          # :company_id
 parent_input_param          # :company
 ```
+
+The parent class and association are read from the **route** (each nested route carries its registration key), not inferred from the URL — which is why a `singular: true` parent works as a parent despite contributing no id segment. There is no `parent_route_param`.
 
 ## Parent vs entity scoping
 

--- a/.claude/skills/plutonium-wizard/SKILL.md
+++ b/.claude/skills/plutonium-wizard/SKILL.md
@@ -127,6 +127,8 @@ end
 
 `condition:` can also read `anchor`. Branch-hidden steps' data is pruned before `execute`. **Must be nil-safe** (see Critical).
 
+Conditions are re-evaluated against the submission that was just staged, so a step (including `review`) may be gated on an answer from the step immediately before it — the revealed steps become reachable on that same POST. When a step's answer reveals nothing after it, that POST ends the flow and runs `execute`.
+
 ## Field reuse — `using:` a model
 
 `using:` is a **step option** (not a block method) and targets a **model only**.

--- a/.claude/skills/plutonium-wizard/SKILL.md
+++ b/.claude/skills/plutonium-wizard/SKILL.md
@@ -183,7 +183,7 @@ Validations drive the form's field affordances just like a resource form: `prese
 
 ### Options that depend on the run
 
-The step block runs **once, when the class loads**, so a literal option is frozen for every run. A **proc-valued** field/input option is resolved on **every render**, against the **wizard** — the same receiver a step's `condition:` gets, so `anchor`, `data`, `persisted` and `current_user` read as they do anywhere else in the wizard:
+The step block runs **once, when the class loads**, so a literal option is frozen for every run. A **proc-valued** field/input option is resolved on **every render**. It must **take the form**: `form.wizard` is the run (so `anchor`, `data`, `persisted`, `current_user` are all reachable) and `form.object` is that step's staged data.
 
 ```ruby
 step :plan do
@@ -204,7 +204,7 @@ Three limits worth knowing:
 
 - The **field set** is still fixed at class load — a proc varies an option, not which fields exist. To collect a shape known only at runtime, declare one `structured_input` and let a custom component render the inner controls. For bespoke markup pass a **block** to `input` instead; it renders in the form's context with the field yielded.
 - A **step's** `condition:` runs against the wizard; a **field's** `condition:` runs against the form (`object` = that step's staged data). Only the field-level one is excluded from the resolution above.
-- **Proc options resolve on every form** ([[plutonium-resource]]); only the zero-arity receiver differs here. Elsewhere a zero-arity proc keeps its own binding, because that binding is already useful — one declared in `customize_inputs` closes over the interaction. A step block closes over a throwaway recorder, so the wizard takes its place.
+- **Proc options resolve on every form** ([[plutonium-resource]]), by one rule with no wizard exception: a zero-argument proc keeps its own binding, a one-argument one gets the form. A step block is `instance_exec`'d against an internal field recorder, so `-> { anchor.x }` raises `NameError` — take the form and use `form.wizard`. Same trade a `form_layout` section option makes; an `input` line keeps its meaning when moved between a definition and a step.
 
 ## Attachment fields (file uploads)
 
@@ -305,7 +305,7 @@ end
 | `succeed(v)` / `failed(errs)` | Outcome helpers (alias `success`). `.with_message`, `.with_redirect_response` chainable. |
 | `fail!(msg)` / `fail!(:field, msg)` | Raise a `StepError` from `on_submit`/`execute`. |
 
-Available inside steps, `condition:`, `on_submit`, `on_rollback` and `execute` — and inside a step's **proc-valued field/input options**, which resolve against the wizard too (see **Step internals → Options that depend on the run**).
+Available inside steps, `condition:`, `on_submit`, `on_rollback` and `execute` — and, via `form.wizard`, inside a step's **proc-valued field/input options** (see **Step internals → Options that depend on the run**).
 
 ## Anchoring
 

--- a/docs/reference/behavior/controllers.md
+++ b/docs/reference/behavior/controllers.md
@@ -252,10 +252,12 @@ Routes prefixed `nested_` automatically resolve the parent. See [Tenancy › Nes
 
 ```ruby
 current_parent              # parent record
+current_parent_class        # User
 current_nested_association  # :posts
-parent_route_param          # :user_id
 parent_input_param          # :user
 ```
+
+The nesting is declared by the route, not inferred from the URL: each nested route carries the key of its own registration, and `current_parent_class` / `current_nested_association` read it back. (There is no `parent_route_param` — the id parameter is derived from the parent's own route, and a singular parent contributes none at all.)
 
 Parent fields are excluded from forms/displays by default. Toggle with the [presentation hooks](#presentation-hooks).
 

--- a/docs/reference/resource/definition.md
+++ b/docs/reference/resource/definition.md
@@ -202,19 +202,36 @@ field   :debug_info,       condition: -> { Rails.env.development? }
 
 ## Options that vary per render
 
-Any field/input option may be a **proc**, resolved on every render rather than frozen when the class loads. Arity picks what it receives:
+Any option may be a **proc**, resolved on every render rather than frozen when the class loads. This holds across the whole form DSL — `field`, `input`, `section`/`ungrouped`, `structured_input` and nested inputs. Arity says **whether you want the form**:
 
 ```ruby
 input :tier,  as: :select, choices: ->(form) { form.object.account.available_tiers }
 input :notes, placeholder: -> { "Updated #{Time.current.year}" }
 ```
 
-- **`->(form) { … }`** is handed the form, so `object` (the record being edited), `params` and view helpers are all reachable.
-- **`-> { … }`** is called as-is, keeping whatever it closed over. That matters for an option declared inside an interaction's `customize_inputs`, which closes over the interaction: `choices: -> { reviewer_choices }` resolves against it.
+- **`-> { … }`** is called as-is, keeping whatever it closed over — it means what it reads like where you wrote it. Nothing rebinds `self`. That is what lets an option declared inside an interaction's `customize_inputs` reach the interaction, private helpers included: `choices: -> { reviewer_choices }`.
+- **`->(form) { … }`** is handed the form, so `object` (the record being edited), `params` and view helpers are reachable. Use it whenever the value depends on what is being rendered.
 
-`condition:` is the exception — it is evaluated separately at render (above), always against the form.
+The rule holds on wizard steps too — but there a zero-argument proc closes over an internal field recorder, so options must take the form and read the run off it: `->(form) { form.wizard.anchor.tiers }`. See [Wizard DSL › Runtime input options](/reference/wizard/dsl#runtime-input-options).
 
-A wizard step resolves a zero-arity proc against the **wizard** instead, since a step block closes over a throwaway recorder rather than anything useful. See [Wizard DSL › Runtime input options](/reference/wizard/dsl#runtime-input-options).
+### `condition:` is not an option
+
+`condition:` follows a different rule, and it is worth knowing why rather than memorising it as an exception. The two are different kinds of thing:
+
+| | asks | so it | receiver |
+|---|---|---|---|
+| an **option** (`choices:`, `label:`, `collapsed:`, …) | "what value should this have?" | may or may not care about the render — so it means what it reads like where you wrote it, and takes `form` when it does care | its own closure, or the form |
+| **`condition:`** | "should this render *here, now*?" | is a question about the render context by definition — there is no useful reading of it that ignores that context | always the thing doing the rendering |
+
+So `condition:` always runs **against** its context and reads it with no argument — and "its context" is whatever is rendering: the form for a field, section or nested input; the component for a `column` or `display`; the **wizard** for a step's `condition:` (evaluated in the runner to decide which steps exist, before any form is built); a condition context for an action or scope.
+
+```ruby
+input   :notes,     condition: -> { object.published? }        # form
+display :audit_log, condition: -> { current_user.admin? }      # display component
+step    :billing,   condition: -> { data.plan.tier == "pro" }  # wizard, no form exists yet
+```
+
+That is why it cannot take a `form` argument the way an option does: in several of those places there is no form.
 
 ## Dynamic forms (`pre_submit`)
 
@@ -543,14 +560,25 @@ Groups a set of fields under an optional heading.
 | `columns:` | Positive Integer. Overrides the section grid column count (e.g. `columns: 2`). Omit to use the form's default responsive grid. Must be a positive Integer — any other value raises. (Literal only — not dynamic.) |
 | `condition:` | Lambda evaluated in the form instance context — same semantics as `input ..., condition:`. `object`, `current_user`, helpers etc. are all available. A falsey result hides the entire section and withholds its fields (they do not spill into `ungrouped`). |
 
-Every option except `columns:` may be either a literal **or a proc** resolved at render time in the same form instance context as `condition:` (so `object`, `current_user`, `params`, helpers are all available). This makes the layout record-aware — e.g. collapse a section by default only for existing records:
+Every option except `columns:` may be either a literal **or a proc** resolved at render time, following the same arity rule as every other option ([Options that vary per render](#options-that-vary-per-render)): take a `form` argument to read the render context. This makes the layout record-aware — e.g. collapse a section by default only for existing records:
 
 ```ruby
 section :advanced, :seo_title, :notes,
   collapsible: true,
-  collapsed: -> { object.persisted? },          # open for new, collapsed for edits
-  label: -> { object.new_record? ? "Set up" : "Advanced" }
+  collapsed: ->(form) { form.object.persisted? },          # open for new, collapsed for edits
+  label: ->(form) { form.object.new_record? ? "Set up" : "Advanced" }
 ```
+
+::: warning Breaking change in 0.63
+Section options previously took a **zero-argument** proc evaluated against the form (`collapsed: -> { object.persisted? }`). They now follow the same rule as every other option, where a zero-argument proc keeps its own binding — and a `form_layout` block is evaluated against the layout builder, so `object` there is a `NameError`.
+
+```ruby
+- collapsed: -> { object.persisted? }
++ collapsed: ->(form) { form.object.persisted? }
+```
+
+It fails loudly, never silently. `condition:` is unchanged — it is still evaluated against the form and still reads `object` with no argument.
+:::
 
 A section that resolves to **zero fields** — every declared field filtered out by the permitted set, or no field assigned — renders nothing at all (no heading, no grid). This keeps forms clean when fewer attributes are permitted than declared (notably `+ New`, where the create policy often permits a subset). The check is purely "are there fields to render"; it does **not** evaluate per-field `condition:` procs (those run later, at field render). So if you want a whole section to appear only under some state, gate it with the section's own `condition:` rather than relying on every field inside it being hidden:
 
@@ -616,7 +644,7 @@ A `section` only renders the fields that are actually in the form's permitted se
 
 `form_layout` is also available on `Plutonium::Interaction::Base`. The same DSL groups the interaction's `attribute` declarations into sections. Interaction forms (`Plutonium::UI::Form::Interaction`) pick up the layout automatically — no extra wiring needed.
 
-Dynamic options and `condition:` work here too, with one difference: in an interaction form `object` is the **interaction instance** (not a record). For a record action, the record is `object.resource` — so e.g. `collapsed: -> { object.resource.archived? }`.
+Dynamic options and `condition:` work here too, with one difference: on an interaction form the form's `object` is the **interaction instance** (not a record). For a record action, the record is `object.resource` — so e.g. `collapsed: ->(form) { form.object.resource.archived? }`, and `condition: -> { object.resource.archived? }` (which is form-evaluated, so it needs no argument).
 
 ```ruby
 class PublishPostInteraction < Plutonium::Interaction::Base

--- a/docs/reference/tenancy/nested-resources.md
+++ b/docs/reference/tenancy/nested-resources.md
@@ -62,10 +62,12 @@ You don't add hidden parent fields or filter queries manually.
 
 ```ruby
 current_parent              # parent record (e.g. Company instance)
+current_parent_class        # parent class (e.g. Company)
 current_nested_association  # association name (e.g. :properties)
-parent_route_param          # URL param (e.g. :company_id)
 parent_input_param          # form param / association name (e.g. :company)
 ```
+
+Each nested route carries the key of its own registration, so the parent class and association are **read from the route** rather than reconstructed from the URL. That is what lets a resource registered `singular: true` act as a parent at all — it contributes no id parameter, so there is nothing in the path to infer from.
 
 ## Parent vs entity scoping
 

--- a/docs/reference/wizard/dsl.md
+++ b/docs/reference/wizard/dsl.md
@@ -85,35 +85,33 @@ See [plutonium-resource › Definition](/reference/resource/definition) for the 
 
 #### Runtime input options
 
-A step's fields are fixed when the class loads, so a **proc** is how an option depends on the run. Proc-valued field/input options are resolved on every render, **against the wizard** — the same receiver a step's `condition:` gets, so `anchor`, `data`, `persisted` and `current_user` read exactly as they do everywhere else in the wizard:
+A step's fields are fixed when the class loads, so a **proc** is how an option depends on the run. Proc-valued field/input options are resolved on every render, and the proc **takes the form** — `form.wizard` is the run, `form.object` is that step's staged data:
 
 ```ruby
 step :plan do
   attribute :tier
-  input :tier, as: :select, choices: -> { anchor.available_tiers }
+  input :tier, as: :select, choices: ->(form) { form.wizard.anchor.available_tiers }
 end
 ```
+
+`form.wizard` is the same object `execute` and a step's `condition:` run against, so `anchor`, `data`, `persisted` and `current_user` are all reachable through it.
 
 It is also how a custom component receives per-run configuration:
 
 ```ruby
-input :answers, as: MyManifestComponent, config: -> { anchor.manifest }
+input :answers, as: MyManifestComponent, config: ->(form) { form.wizard.anchor.manifest }
 ```
 
-A one-argument proc still takes the form, as on any other form, for `object` (this step's staged data), `params` and helpers:
+::: warning Take the argument
+A **zero-argument** proc here will not work. It keeps its own binding — the same rule as [everywhere else](/reference/resource/definition#options-that-vary-per-render) — and a step block is `instance_exec`'d against an internal field recorder when the class loads, so `-> { anchor.available_tiers }` looks `anchor` up on that recorder and raises `NameError`.
 
-```ruby
-input :tier, as: :select, choices: ->(form) { form.object.region_tiers }
-```
+That is deliberate: it is the same trade a `form_layout` section option makes, and it means an `input` line keeps its meaning when moved between a definition and a step. Nothing silently swaps `self`.
+:::
 
 Two limits worth knowing:
 
 - The **field set** is still fixed at class load. A proc varies an option, not which fields exist. To collect a shape known only at runtime, declare one `structured_input` and let a custom component render the inner controls. For bespoke markup, pass a block to `input` instead — it renders in the form's context with the field yielded.
-- `condition:` is **not** resolved this way. A *step's* `condition:` runs against the wizard; a *field's* `condition:` runs against the form, where `object` is that step's staged data.
-
-::: tip What differs from other forms
-Proc options resolve on **every** form (see [Definition › inputs](/reference/resource/definition)); only the zero-arity receiver differs. Elsewhere a zero-arity proc keeps its own binding, because that binding is already useful — one declared in an interaction's `customize_inputs` closes over the interaction. A step block is `instance_exec`'d against a throwaway recorder, so there is no binding worth keeping and the wizard takes its place.
-:::
+- `condition:` is **not** resolved this way, because it is not an option — it asks "should this render here, now?", so it always runs *against* the thing doing the rendering and reads it with no argument. A *step's* `condition:` runs against the **wizard** (it is evaluated in the runner to decide which steps exist, before any form is built — which is exactly why it can't be handed a form); a *field's* runs against the **form**, where `object` is that step's staged data. See [Definition › `condition:` is not an option](/reference/resource/definition#condition-is-not-an-option).
 
 ### `using:` a model
 
@@ -345,7 +343,7 @@ Available inside steps, `condition:`, `on_submit`, `on_rollback`, and `execute`:
 | `anchor` | The record the wizard was launched against. Raises `NotAnchoredError` if the wizard isn't `anchored`. |
 | `persisted[:step_key]` | Record(s) a per-step `on_submit` registered via `persist`. Lazily rehydrated on first access (located from stored GlobalIDs the first time you read the key, memoized thereafter). |
 
-A **proc-valued field/input option** on a step resolves against the wizard too, so the same accessors apply there — see [Runtime input options](#runtime-input-options).
+A **proc-valued field/input option** on a step reaches the same accessors through `form.wizard` — see [Runtime input options](#runtime-input-options).
 
 ## Outcome helpers
 

--- a/lib/plutonium.rb
+++ b/lib/plutonium.rb
@@ -26,6 +26,15 @@ module Plutonium
   # Custom error class for Plutonium-specific exceptions
   class Error < StandardError; end
 
+  # Raised when a resource registered `singular: true` has an authorized scope
+  # that resolves to more than one record.
+  #
+  # A singular route carries no :id — the scope IS the identification — so the
+  # promise `singular: true` makes is "exactly one record here". A scope that
+  # returns several silently nests (or shows) an arbitrary row, so it fails
+  # instead. Always a registration/policy mismatch, never user input.
+  class SingularScopeError < Error; end
+
   # Turbo frame id used by the modal/slideover renderer. The layout wraps
   # itself in this frame, in_modal? checks against it, and Action and
   # Definition default to targeting it. Kept as a single constant so the

--- a/lib/plutonium/resource/controller.rb
+++ b/lib/plutonium/resource/controller.rb
@@ -245,8 +245,7 @@ module Plutonium
       # Plutonium::Routing::PARENT_KEY_PARAM); all that is
       # left is to load it. A plural parent narrows by the id in the path. A
       # singular parent has no id to narrow by — it is whichever record the
-      # viewer's scope resolves to, the same rule resource_record_relation
-      # applies when the current resource is itself singular.
+      # viewer's scope resolves to, which is what `singular: true` promises.
       #
       # Memoised through `defined?` so a genuine nil is remembered rather than
       # re-resolved on every call.
@@ -263,7 +262,7 @@ module Plutonium
               # would quietly hand back whichever row sorted first if the scope
               # ever resolved to several, and silently nesting under the wrong
               # parent is far worse than failing loudly.
-              scope.sole
+              resolve_singular_parent(scope, parent_class)
             else
               # The id parameter is named by the parent's own route, so it is
               # derived rather than discovered. Scanning path_parameters for
@@ -274,6 +273,26 @@ module Plutonium
             parent.tap { authorize! parent, to: :read? }
           end
         end
+      end
+
+      # `sole`, but reporting the registration mistake instead of the symptom.
+      #
+      # `SoleRecordExceeded` says "Wanted only one User" — true, and useless to
+      # the person who has to fix it, because the cause is two files away: the
+      # resource was registered `singular: true` while its policy still scopes to
+      # many. Say that, and name both halves of the fix.
+      # @raise [Plutonium::SingularScopeError]
+      def resolve_singular_parent(scope, parent_class)
+        scope.sole
+      rescue ActiveRecord::SoleRecordExceeded
+        # Deliberately says nothing about the viewer: this runs while raising, and
+        # reaching for `current_user` here would swap the useful error for a
+        # NoMethodError in any context that has no such helper.
+        raise Plutonium::SingularScopeError,
+          "#{parent_class} is registered `singular: true`, but its authorized scope " \
+          "resolved to #{scope.count} records. A singular route carries no :id, so the " \
+          "scope has to identify exactly one record. Either give #{parent_class}'s policy " \
+          "a `relation_scope` that narrows to one, or register it without `singular: true`."
       end
 
       # The parent resource class, taken from the registration rather than

--- a/lib/plutonium/ui/breadcrumbs.rb
+++ b/lib/plutonium/ui/breadcrumbs.rb
@@ -151,24 +151,21 @@ module Plutonium
       end
 
       def collect_plural_resource_breadcrumbs(items)
-        # Nested through the parent when there is one, so the trail links back
-        # into the nesting the request arrived through rather than jumping out
-        # to the resource's top-level index.
-        parent = current_parent
-
-        # Resource index link
+        # No `parent:` here on purpose: Resource::Controller#resource_url_args_for
+        # already defaults it to `current_parent` (and supplies
+        # `current_nested_association` with it), so both links nest themselves
+        # when the request arrived through a nesting. Passing it explicitly reads
+        # like it changes something; it doesn't. The parent segments above pass
+        # `parent: nil` precisely to opt OUT of that default.
         items << segment(
           nestable_resource_name_plural(resource_class),
-          resource_url_for(resource_class, parent: parent)
+          resource_url_for(resource_class)
         )
 
         # Record itself (for non-singular routes only)
         return unless resource_record!.persisted? && action_name != "show"
 
-        items << segment(
-          display_name_of(resource_record!),
-          resource_url_for(resource_record!, parent: parent)
-        )
+        items << segment(display_name_of(resource_record!), resource_url_for(resource_record!))
       end
 
       # Stands in for whatever the controller folded away, the way GitHub

--- a/lib/plutonium/ui/form/concerns/renders_nested_resource_fields.rb
+++ b/lib/plutonium/ui/form/concerns/renders_nested_resource_fields.rb
@@ -23,11 +23,17 @@ module Plutonium
           class NestedFieldContext
             attr_reader :name, :definition, :options, :permitted_fields
 
-            def initialize(name:, definition:, resource_class:, resource_definition:, object_class:)
+            # @param declared_options [Hash] the nested input's own options, already
+            #   proc-resolved by the form (the context has no form to resolve
+            #   against). Everything merged in below — nested-attribute macro,
+            #   limits — is derived from the model, never authored, so this is the
+            #   only half that can carry a proc.
+            def initialize(name:, definition:, resource_class:, resource_definition:, object_class:, declared_options:)
               @name = name
               @definition = definition
               @resource_definition = resource_definition
               @resource_class = resource_class
+              @declared_options = declared_options
               @options = build_options
               @permitted_fields = build_permitted_fields
               @object_class = object_class
@@ -52,7 +58,7 @@ module Plutonium
             private
 
             def build_options
-              options = @resource_definition.defined_nested_inputs[@name][:options].dup || {}
+              options = @declared_options.dup
               merge_nested_fields_options(options)
               set_nested_fields_limits(options)
               options
@@ -97,12 +103,19 @@ module Plutonium
               return
             end
 
+            # Resolved here rather than in the context: `condition:` above needs the
+            # raw proc (resolve_option_procs deliberately leaves it alone, but it is
+            # also evaluated before this point), and the context has no form to
+            # resolve the rest against.
+            declared_options = resolve_option_procs(nested_input_definition[:options] || {})
+
             context = NestedFieldContext.new(
               name: name,
               definition: build_nested_fields_definition(name),
               resource_class: resource_class,
               resource_definition: resource_definition,
-              object_class: nested_input_definition[:options]&.fetch(:object_class, nil)
+              object_class: declared_options[:object_class],
+              declared_options: declared_options
             )
 
             render_nested_field_container(context) do

--- a/lib/plutonium/ui/form/concerns/renders_structured_inputs.rb
+++ b/lib/plutonium/ui/form/concerns/renders_structured_inputs.rb
@@ -15,7 +15,11 @@ module Plutonium
 
           def render_structured_input(name)
             entry = resource_definition.defined_structured_inputs[name]
-            options = entry[:options] || {}
+            # Same proc resolution the inner fields already get (they render
+            # through render_simple_resource_field on this same form), so
+            # `repeat:`/`fields:` can depend on the request — or, on a wizard
+            # step, on the run: the receiver rule is the form's, not ours.
+            options = resolve_option_procs(entry[:options] || {})
             definition = structured_input_fields_definition(entry)
             fields = options[:fields] || definition.defined_inputs.keys
             repeat = options[:repeat]

--- a/lib/plutonium/ui/form/resource.rb
+++ b/lib/plutonium/ui/form/resource.rb
@@ -132,10 +132,11 @@ module Plutonium
             # section's own `condition:`.
             next if resolved.fields.empty?
 
-            # `columns` stays a validated literal; everything else may be a proc.
-            options = section.options.to_h do |key, value|
-              [key, (key != :condition && value.is_a?(Proc)) ? instance_exec(&value) : value]
-            end
+            # `columns` stays a validated literal (the Builder rejects a non-Integer
+            # at declaration); `label`/`description`/`collapsible`/`collapsed` may be
+            # procs, resolved by the SAME arity rule as a field/input option so
+            # `-> { … }` means one thing across the whole form DSL.
+            options = resolve_option_procs(section.options)
             Plutonium::Definition::FormLayout::ResolvedSection.new(
               section: Plutonium::Definition::FormLayout::Section.new(
                 key: section.key, fields: section.fields, options: options.freeze
@@ -350,25 +351,39 @@ module Plutonium
           end
         end
 
-        # Resolve proc-valued field/input options for THIS render, so any option
-        # can vary per request rather than being frozen when the class loads.
+        # Resolve proc-valued options for THIS render, so any option can vary per
+        # request rather than being frozen when the class loads. One rule for the
+        # whole form DSL: `field`/`input`, `section`/`ungrouped`, `structured_input`
+        # and nested inputs all route through here.
         #
-        # Arity decides the receiver, matching what Phlexi already does for
-        # validators:
+        # Arity says whether you want the form, NOT which `self` you get:
         #
-        #   -> { … }       called as-is, keeping its own binding
-        #   ->(form) { … } called with this form, for `object`/`params`/helpers
+        #   -> { … }       a plain call — means what it reads like where it was
+        #                  written, closure and all
+        #   ->(form) { … } handed this form, for `object`/`params`/helpers
         #
-        # The binding is kept rather than rebound because on these forms it is
-        # already the useful one: an option declared in an interaction's
-        # `customize_inputs` closes over the interaction (`choices: -> {
-        # reviewer_choices }`), and `instance_exec` would throw that away. A
-        # closure can be handed context as an argument; context cannot recover a
-        # closure. Form::Wizard overrides this, because a step block closes over
-        # a throwaway recorder and so has no binding worth keeping.
+        # This is `choices:`'s rule, adopted rather than replaced. Phlexi has
+        # always resolved a `choices:` proc with a plain `.call`, so it is both
+        # the oldest of these semantics and the only one that predates Plutonium's
+        # own option layer — and it is the unsurprising one: nothing silently
+        # rebinds `self` out from under a lambda. `section :x, collapsed: -> { … }`
+        # (v0.60) followed the other convention and was migrated to `->(form)` to
+        # meet it here.
         #
-        # `condition:` is excluded: it is evaluated separately at render, and
-        # resolving it here would collapse it to a boolean first.
+        # Form::Wizard overrides the zero-arity case, because a step block is
+        # instance_exec'd against a throwaway recorder — the closure there holds
+        # nothing, so the wizard takes its place.
+        #
+        # `condition:` is excluded because it is a different kind of thing, not
+        # because it is an awkward leftover. An option asks "what value should
+        # this have?" and may not care about the render; `condition:` asks
+        # "should this render here, now?", which is a question about the render
+        # context by definition. So it is evaluated separately, always AGAINST
+        # its context — and that context is not always a form (a `column`'s is the
+        # table, a step's is the wizard, an action's is a ConditionContext), which
+        # is why it cannot take a `form` argument the way an option does.
+        # Resolving it here would also collapse it to a boolean before the render
+        # site that owns it gets to ask.
         def resolve_option_procs(options)
           return options if options.blank?
 

--- a/lib/plutonium/ui/form/wizard.rb
+++ b/lib/plutonium/ui/form/wizard.rb
@@ -16,11 +16,11 @@ module Plutonium
         # @param action  [String] the current step's POST URL.
         # @param fields  [Array<Symbol>] the step's renderable field names
         #   (scalar attributes + structured inputs).
-        # @param wizard  [Plutonium::Wizard::Base, nil] the run being rendered,
-        #   used to resolve a step's proc-valued options against. Optional so an
-        #   existing caller keeps working; without it those options pass through
-        #   unresolved, as they do on every other form.
-        def initialize(step:, data:, action:, fields:, wizard: nil, **options, &)
+        # @param wizard  [Plutonium::Wizard::Base] the run being rendered. Exposed
+        #   as `form.wizard` so a step's proc-valued option can reach the run —
+        #   see {#wizard}. Required: it is read during render, so defaulting it to
+        #   nil would only defer the failure to a NoMethodError inside a proc.
+        def initialize(step:, data:, action:, fields:, wizard:, **options, &)
           @step = step
           @wizard = wizard
           options[:key] = :wizard
@@ -32,30 +32,28 @@ module Plutonium
           super(data, **options, &)
         end
 
+        # The run being rendered. Public because a step's proc-valued option is
+        # how an option depends on the run, and reaching the run is the whole
+        # point:
+        #
+        #   input :tier, as: :select,
+        #     choices: ->(form) { form.wizard.anchor.available_tiers }
+        #
+        # Deliberately NOT reached by rebinding a zero-arity proc to the wizard.
+        # A step block is instance_exec'd against a FieldCapture at class load,
+        # so its closure holds nothing useful — but that is equally true of a
+        # `form_layout` block and its Builder, and the answer there is to ask for
+        # the receiver rather than have it swapped in silently. Same answer here:
+        # `-> { … }` means what it reads like wherever it is written, and an
+        # `input` line moved between a definition and a step keeps its meaning.
+        #
+        # `form.object`, alongside this, is the step's staged data.
+        # @return [Plutonium::Wizard::Base]
+        attr_reader :wizard
+
         private
 
-        attr_reader :step, :wizard
-
-        # Same arity rule as every other form; only the zero-arity receiver
-        # differs. A step block is instance_exec'd against a FieldCapture when
-        # the wizard class loads, so a proc declared there closes over a recorder
-        # that holds nothing. There is no binding worth keeping, so it runs
-        # against the wizard instead — where the rest of the wizard DSL already
-        # points:
-        #
-        #   input :tier, as: :select, choices: -> { anchor.available_tiers }
-        #
-        # That is the receiver a step's `condition:` already gets (see
-        # Wizard::Runner), so `anchor`, `data`, `persisted` and `current_user`
-        # read the same in an option as they do anywhere else in the wizard.
-        #
-        # ->(form) { … } still takes the form, as it does elsewhere, for
-        # `object` (this step's staged data), `params` and helpers.
-        def call_option_proc(value)
-          return super unless value.arity.zero? && wizard
-
-          wizard.instance_exec(&value)
-        end
+        attr_reader :step
 
         def form_template
           # The direction defaults to "next"; the nav buttons in the page override

--- a/lib/plutonium/wizard/driving.rb
+++ b/lib/plutonium/wizard/driving.rb
@@ -170,20 +170,12 @@ module Plutonium
         respond_to_wizard_result(runner, result)
       end
 
-      # Advance the current step; if the POSTed step is the last visible step,
-      # finalize. The last visible step is the terminal `review` (no fields), so
-      # finalize runs directly; otherwise validate + stage + move the cursor.
+      # Advance the POSTed step, finalizing when it turns out to end the flow. The
+      # advance-or-finalize decision lives in the runner because it can only be made
+      # AFTER the submission is staged — a step's `condition:` may be gated on an
+      # answer from the very step being submitted. See {Runner#submit}.
       def advance_or_finalize(runner)
-        return runner.finalize if wizard_posting_last_step?(runner)
-
-        runner.advance(params[:step], wizard_params(runner), goto: params[:_goto].presence)
-      end
-
-      # Whether the step being POSTed is the last visible step (so Next → Finish).
-      # Computed BEFORE advancing, since advance moves the cursor past it.
-      def wizard_posting_last_step?(runner)
-        last = runner.visible_path.last
-        last && last.key.to_s == params[:step].to_s
+        runner.submit(params[:step], wizard_params(runner), goto: params[:_goto].presence)
       end
 
       def respond_to_wizard_result(runner, result)

--- a/lib/plutonium/wizard/runner.rb
+++ b/lib/plutonium/wizard/runner.rb
@@ -147,6 +147,43 @@ module Plutonium
         end
       end
 
+      # Submit the posted step: advance through it, then finalize if it turns out
+      # to be the end of the flow (§6.3). This is the driving layer's single entry
+      # point for a forward POST.
+      #
+      # "Is this the last step?" CANNOT be answered before the submission is
+      # staged. Every `condition:` is evaluated against `data`, so a step gated on
+      # an answer from the step being submitted is still hidden at POST time.
+      # Deciding first broke two shapes:
+      #
+      # - a wizard whose later steps are all revealed BY its first step saw a
+      #   visible path of just `[first]`, called it terminal, and finalized — which
+      #   found `first` unsubmitted and bounced back to it, forever. The revealed
+      #   steps were unreachable and no state was ever written.
+      # - a wizard with no `review` step finalized its last step WITHOUT staging
+      #   it, silently dropping that step's params before `execute`.
+      #
+      # So the order is stage, then look: after `advance` the cursor holds the next
+      # visible step, recomputed against the freshly staged data, and a nil cursor
+      # means nothing follows — finish. This also matches what the user sees: the
+      # nav strip renders Finish only on the review step (§7), never on a field
+      # step that merely happens to be last right now.
+      #
+      # The terminal `review` step short-circuits: it declares no fields, so there
+      # is nothing to stage and Finish runs `execute` directly.
+      def submit(step_key, params, goto: nil)
+        step = step_for(step_key)
+        return finalize if step&.review?
+
+        result = advance(step_key, params, goto:)
+        return result unless result.ok?
+        # A cursor target survives → the flow continues (including the `goto:`
+        # "Save & review" shortcut). Nil → `advance` found no next visible step.
+        return result if @state.current_step.present?
+
+        finalize
+      end
+
       # Validate + stage a step, run its `on_submit` (in a transaction), then move
       # the cursor to the next visible step. On validation/`on_submit` failure the
       # cursor does not move and the errors are returned.

--- a/test/dummy/app/definitions/kitchen_sink_definition.rb
+++ b/test/dummy/app/definitions/kitchen_sink_definition.rb
@@ -11,10 +11,14 @@ class KitchenSinkDefinition < ::ResourceDefinition
   form_layout do
     section :identity, :name, :email_address, label: "Identity",
       description: "Who this is"
-    # `collapsed:` is a proc resolved at render in the form/record context —
-    # existing records open collapsed, new records open expanded.
+    # `collapsed:` is a proc resolved at render — existing records open
+    # collapsed, new records open expanded. It takes the form as an argument
+    # because a `form_layout` block is instance_exec'd against the layout
+    # Builder, so a zero-arity proc would close over that and `object` would be
+    # a NameError. `condition:` below is the documented exception: it is
+    # evaluated separately and always runs against the form.
     section :appearance, :favorite_color, :active, :website,
-      collapsible: true, collapsed: -> { object.persisted? }, columns: 2
+      collapsible: true, collapsed: ->(form) { form.object.persisted? }, columns: 2
     section :secret, :secret_token, label: "Secret stuff", condition: -> { false }
     # Lists only a field that is never in the permitted set, so it resolves to
     # zero fields on every render — its chrome must not be emitted.

--- a/test/dummy/app/interactions/reconfigure_kitchen_sink.rb
+++ b/test/dummy/app/interactions/reconfigure_kitchen_sink.rb
@@ -10,15 +10,17 @@ class ReconfigureKitchenSink < ::ResourceInteraction
   input :favorite_color, as: :color
   input :website, as: :url
 
-  # Exercises form_layout inside an interaction form. In this context `object`
-  # is the interaction instance and `object.resource` is the record the action
-  # runs on — so section options can be record-aware here too.
+  # Exercises form_layout inside an interaction form. On an interaction form the
+  # form's `object` is the interaction instance and `object.resource` is the
+  # record the action runs on — so section options can be record-aware here too,
+  # once the proc has been handed the form to read it from.
   form_layout do
     section :basics, :name, label: "Basics", description: "Rename it"
     section :appearance, :favorite_color, :website,
       label: "Appearance",
       collapsible: true,
-      collapsed: -> { object.resource.archived? }, # dynamic: collapsed for archived records
+      # dynamic: collapsed for archived records
+      collapsed: ->(form) { form.object.resource.archived? },
       columns: 2
     ungrouped label: "Anything else"
   end

--- a/test/dummy/app/wizards/configure_widget_wizard.rb
+++ b/test/dummy/app/wizards/configure_widget_wizard.rb
@@ -12,15 +12,27 @@ class ConfigureWidgetWizard < Plutonium::Wizard::Base
 
   step :rename do
     attribute :name, :string
-    # A proc-valued input option resolves against the wizard on every render, so
-    # `anchor` reads here exactly as it does in `condition:` or `execute`.
-    input :name, placeholder: -> { "Currently #{anchor.name}" }
+    # A proc-valued input option is resolved on every render, so the value can
+    # depend on the run. It takes the form because a step block is instance_exec'd
+    # against a field recorder at class load — the same reason a `form_layout`
+    # section option takes it — and `form.wizard` is this run. A zero-arity
+    # `-> { anchor.name }` would look up `anchor` on the recorder and raise.
+    input :name, placeholder: ->(form) { "Currently #{form.wizard.anchor.name}" }
     validates :name, presence: true
 
     # The case that motivated it: choices drawn from the anchor. Left optional so
     # the other tests can post this step without supplying it.
     attribute :rename_reason, :string
-    input :rename_reason, as: :select, choices: -> { ["#{anchor.name} was wrong", "Other"] }
+    input :rename_reason, as: :select,
+      choices: ->(form) { ["#{form.wizard.anchor.name} was wrong", "Other"] }
+
+    # A step is NOT an exception to the arity rule: a zero-argument proc keeps
+    # its own binding here exactly as it does on any other form. Nothing rebinds
+    # it to the wizard — which is why the option above has to ask for the form.
+    # This closes over a class-body local, the only binding a step block has.
+    banner = "declared at class load"
+    attribute :note, :string
+    input :note, placeholder: -> { banner }
   end
 
   review label: "Review"

--- a/test/dummy/app/wizards/late_reveal_wizard.rb
+++ b/test/dummy/app/wizards/late_reveal_wizard.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Every step AFTER the first is revealed BY the first step's answer, so before
+# `details` is submitted `details` is the ONLY visible step. Used to prove the
+# driving layer decides advance-vs-finalize AFTER staging the submission:
+# deciding first read `details` as the last visible step, finalized, found
+# `details` unsubmitted and bounced back to it — forever, with `setup`
+# unreachable and no run ever written.
+#
+# Picking `basic` hides everything after `details`, so that POST legitimately
+# ends the flow (a conditional `review` that branches out is still terminal).
+class LateRevealWizard < Plutonium::Wizard::Base
+  presents label: "Late reveal"
+
+  # A bare relaunch always mints a fresh run — this flow is started clean.
+  on_relaunch :new
+
+  step :details do
+    attribute :template, :string
+    input :template, as: :select, choices: %w[pro basic]
+    validates :template, presence: true
+  end
+
+  step :setup, condition: -> { data.details.template == "pro" } do
+    attribute :note, :string
+    input :note
+  end
+
+  review label: "Review", condition: -> { data.details.template == "pro" }
+
+  def execute = succeed.with_message("Done")
+
+  # Portal-level wizard with no resource policy — gate it to authenticated users.
+  def authorize? = current_user.present?
+end

--- a/test/dummy/packages/admin_portal/config/routes.rb
+++ b/test/dummy/packages/admin_portal/config/routes.rb
@@ -12,6 +12,11 @@ AdminPortal::Engine.routes.draw do
   # prove a POST to an unreachable (branch-hidden) step is refused before it runs.
   register_wizard ::BranchGuardWizard, at: "branch-guard"
 
+  # A wizard whose later steps are revealed by its FIRST step's answer — used to
+  # prove the first POST advances (and can finalize) correctly even though the
+  # pre-submission visible path is just that one step.
+  register_wizard ::LateRevealWizard, at: "late-reveal"
+
   # An `anonymous` (guest) wizard mounted on a PUBLIC route (pre-login). Because
   # the portal engine is mounted behind the host's auth constraint, this draws on
   # the MAIN app route set instead (outside the constraint) — see §4.5 / the

--- a/test/dummy/packages/locus_portal/app/policies/locus_portal/user_policy.rb
+++ b/test/dummy/packages/locus_portal/app/policies/locus_portal/user_policy.rb
@@ -1,0 +1,12 @@
+class LocusPortal::UserPolicy < ::UserPolicy
+  include LocusPortal::ResourcePolicy
+
+  # locus_portal registers User as a SINGULAR resource and has no entity scoping
+  # at all, so the base policy's scope is every user in the system. A singular
+  # route carries no :id, so the scope has to identify exactly one record — see
+  # OrgPortal::UserPolicy for the same reasoning, and
+  # Plutonium::SingularScopeError for what it costs when it doesn't hold.
+  relation_scope do |relation|
+    default_relation_scope(relation).where(id: user.id)
+  end
+end

--- a/test/dummy/packages/locus_portal/app/policies/locus_portal/user_profile_policy.rb
+++ b/test/dummy/packages/locus_portal/app/policies/locus_portal/user_profile_policy.rb
@@ -1,0 +1,10 @@
+class LocusPortal::UserProfilePolicy < ::UserProfilePolicy
+  include LocusPortal::ResourcePolicy
+
+  # Same reasoning as LocusPortal::UserPolicy: registered singular, portal has no
+  # entity scoping, so the base scope is every profile. Narrowed to the viewer's
+  # own, which is what a singular profile route means.
+  relation_scope do |relation|
+    default_relation_scope(relation).where(user_id: user.id)
+  end
+end

--- a/test/dummy/packages/org_portal/app/policies/org_portal/user_policy.rb
+++ b/test/dummy/packages/org_portal/app/policies/org_portal/user_policy.rb
@@ -1,0 +1,15 @@
+class OrgPortal::UserPolicy < ::UserPolicy
+  include OrgPortal::ResourcePolicy
+
+  # org_portal registers User as a SINGULAR resource (`resource :user`), and a
+  # singular route carries no :id — the scope is the identification. So the scope
+  # has to resolve to exactly one record, which the base policy's entity scope
+  # (every member of the org) does not. Without this, /user is an arbitrary
+  # member and every /user/nested_* route raises Plutonium::SingularScopeError.
+  #
+  # Narrowed to the viewer, which is what a singular User in a tenant portal
+  # means anyway: "my account here", not "some member".
+  relation_scope do |relation|
+    default_relation_scope(relation).where(id: user.id)
+  end
+end

--- a/test/integration/admin_portal/form_layout_interaction_test.rb
+++ b/test/integration/admin_portal/form_layout_interaction_test.rb
@@ -4,8 +4,8 @@ require "test_helper"
 
 # form_layout works in interaction forms too (Form::Interaction < Form::Resource),
 # including dynamic options: ReconfigureKitchenSink declares
-# `collapsed: -> { object.resource.archived? }`, resolved in the interaction form
-# context where `object` is the interaction and `object.resource` the record.
+# `collapsed: ->(form) { form.object.resource.archived? }` — on an interaction
+# form the form's `object` is the interaction and `object.resource` the record.
 class AdminPortal::FormLayoutInteractionTest < ActionDispatch::IntegrationTest
   include IntegrationTestHelper
 
@@ -36,7 +36,7 @@ class AdminPortal::FormLayoutInteractionTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "Anything else"
   end
 
-  test "dynamic collapsed: is resolved against object.resource in the interaction" do
+  test "dynamic collapsed: is resolved against form.object.resource in the interaction" do
     active = KitchenSink.create!(name: "Active", organization: @org, status: :active)
     archived = KitchenSink.create!(name: "Archived", organization: @org, status: :archived)
 

--- a/test/integration/admin_portal/form_layout_rendering_test.rb
+++ b/test/integration/admin_portal/form_layout_rendering_test.rb
@@ -43,7 +43,9 @@ class AdminPortal::FormLayoutRenderingTest < ActionDispatch::IntegrationTest
   end
 
   test "a dynamic collapsed: proc is resolved in the record context" do
-    # :appearance declares `collapsed: -> { object.persisted? }`.
+    # :appearance declares `collapsed: ->(form) { form.object.persisted? }` — the
+    # proc takes the form because a `form_layout` block is instance_exec'd
+    # against the layout Builder, so a zero-arity proc closes over that.
     # New record → not persisted → the Appearance <details> is open.
     get "/admin/kitchen_sinks/new"
     new_tag = response.body.match(/(<details[^>]*>)\s*<summary[^>]*>\s*Appearance/m)

--- a/test/integration/admin_portal/wizard_late_reveal_test.rb
+++ b/test/integration/admin_portal/wizard_late_reveal_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "plutonium/testing"
+
+# Regression: a wizard whose later steps are gated on an answer from its FIRST
+# step. Every `condition:` is evaluated against `data`, so at the moment that
+# first step is POSTed the steps it reveals are still hidden — the visible path
+# is just `[details]`.
+#
+# The driving layer used to decide advance-vs-finalize from that pre-submission
+# path: it read `details` as terminal and finalized, which found `details`
+# unsubmitted and PRG'd back to it. The revealed steps were unreachable and no
+# run was ever written. See `Plutonium::Wizard::Runner#submit`.
+class AdminPortal::WizardLateRevealTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+  include Plutonium::Testing::AuthHelpers
+
+  setup do
+    @admin = create_admin!
+    login_as(@admin, portal: :admin)
+    Plutonium::Wizard::Session.delete_all
+  end
+
+  def base = "/admin/late-reveal"
+
+  # Launch and return the tokened run base URL.
+  def launch
+    get base
+    assert_response :redirect
+    token = URI(response.location).path[%r{/late-reveal/([^/]+)/}, 1]
+    assert token, "launch redirects into a tokened run URL (#{response.location})"
+    "#{base}/#{token}"
+  end
+
+  test "the first POST advances into the step its own answer reveals" do
+    run = launch
+
+    post "#{run}/details", params: {wizard: {template: "pro"}, _direction: "next"}
+    assert_response :redirect
+    assert_match %r{/setup\z}, URI(response.location).path,
+      "the revealed step must be reachable, not a bounce back to :details"
+
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, %(name="wizard[note]")
+
+    session = Plutonium::Wizard::Session.where(status: "in_progress").first
+    assert session, "the advance must have written the run"
+    assert_equal "pro", session.data.dig("details", "template"),
+      "the submission that revealed the step must itself be staged"
+  end
+
+  test "the first POST finalizes when its answer reveals nothing after it" do
+    run = launch
+
+    post "#{run}/details", params: {wizard: {template: "basic"}, _direction: "next"}
+    assert_response :redirect
+    refute_match %r{/details\z}, URI(response.location).path,
+      "with nothing left to collect the flow completes instead of bouncing"
+
+    assert_equal 0, Plutonium::Wizard::Session.where(status: "in_progress").count,
+      "a repeatable wizard clears its run on completion"
+  end
+
+  test "an invalid first POST re-renders the step instead of finalizing" do
+    run = launch
+
+    post "#{run}/details", params: {wizard: {template: ""}, _direction: "next"}
+    assert_response :unprocessable_content
+    assert_includes response.body, %(name="wizard[template]")
+  end
+end

--- a/test/integration/org_portal/anchored_wizard_test.rb
+++ b/test/integration/org_portal/anchored_wizard_test.rb
@@ -45,9 +45,10 @@ class OrgPortal::AnchoredWizardTest < ActionDispatch::IntegrationTest
   end
 
   # A step's fields are fixed when the class loads, so a proc is how an option
-  # depends on the run. It resolves against the wizard, the same receiver a
-  # step's `condition:` gets, so `anchor` reads the same in both.
-  test "a proc-valued input option resolves against the wizard" do
+  # depends on the run. The proc takes the form and reads the run off it
+  # (`form.wizard`) — the same shape a `form_layout` section option uses — rather
+  # than having `self` swapped to the wizard behind its back.
+  test "a proc-valued input option reaches the run through the form" do
     get "#{base}/rename"
 
     assert_response :success
@@ -62,14 +63,24 @@ class OrgPortal::AnchoredWizardTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Currently Renamed since boot"
   end
 
-  # The motivating case: without this a step's `choices:` proc is called with a
-  # FieldCapture as `self`, so reading `anchor` raises a NameError naming an
-  # internal the author never wrote.
+  # The motivating case: choices drawn from the anchor. A zero-arity proc could
+  # not express this — a step block is instance_exec'd against a FieldCapture, so
+  # its closure holds an internal the author never wrote.
   test "choices drawn from the anchor materialise into options" do
     get "#{base}/rename"
 
     assert_response :success
     assert_includes response.body, "#{@widget.name} was wrong"
+  end
+
+  # The other half of the rule: a step is not an exception. A zero-argument proc
+  # keeps its own binding here as it does on every other form — if the wizard
+  # rebound it, `banner` would be looked up on the wizard and raise.
+  test "a zero-argument proc on a step keeps its own binding" do
+    get "#{base}/rename"
+
+    assert_response :success
+    assert_includes response.body, "declared at class load"
   end
 
   test "the anchor a proc option sees is the scoped one, not another tenant's" do

--- a/test/integration/org_portal/singular_parent_nesting_test.rb
+++ b/test/integration/org_portal/singular_parent_nesting_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "plutonium/testing"
+
+# Nesting under a resource registered `singular: true`. The parent segment carries
+# no :id, so the parent is whichever record the viewer's authorized scope resolves
+# to — which only works because the scope resolves to exactly one (see
+# OrgPortal::UserPolicy / LocusPortal::UserPolicy). When it doesn't, the framework
+# says so rather than nesting under an arbitrary row: Plutonium::SingularScopeError.
+class OrgPortal::SingularParentNestingTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+  include Plutonium::Testing::AuthHelpers
+
+  setup do
+    @org = create_organization!
+    @user = create_user!
+    create_membership!(organization: @org, user: @user)
+    # A second member, so the parent scope would resolve to many if it weren't narrowed.
+    create_membership!(organization: @org, user: create_user!)
+    login_as(@user, portal: :user)
+  end
+
+  def prefix = "/org/#{@org.to_param}"
+
+  test "a has_many nested under a singular parent resolves that parent" do
+    mine = Comment.create!(body: "Mine", user: @user, commentable: create_post!(user: @user, organization: @org))
+    theirs = Comment.create!(body: "Theirs", user: User.where.not(id: @user.id).first,
+      commentable: create_post!(user: @user, organization: @org))
+
+    get "#{prefix}/user/nested_comments"
+
+    assert_response :success
+    assert_includes response.body, mine.body
+    refute_includes response.body, theirs.body,
+      "the listing must be scoped to the resolved singular parent, not every user's"
+  end
+
+  test "a has_one nested under a singular parent resolves that parent" do
+    get "#{prefix}/user/nested_user_profile/new"
+    assert_response :success
+  end
+
+  test "the unscoped portal resolves a singular parent the same way" do
+    get "/locus/user/nested_authored_posts"
+    assert_response :success
+  end
+
+  # The failure mode the narrowing exists to prevent is covered as a unit test
+  # (test/plutonium/resource/controller_test.rb) — by design no route in the
+  # dummy app nests under an un-narrowed singular parent any more, which is the
+  # whole point of the two policies above.
+end

--- a/test/plutonium/resource/controller_test.rb
+++ b/test/plutonium/resource/controller_test.rb
@@ -70,6 +70,48 @@ class Plutonium::Resource::ControllerTest < Minitest::Test
     assert_nil controller.send(:current_nested_association)
   end
 
+  # Resolving a SINGULAR parent — the route carries no :id, so the scope is the
+  # identification and it has to name exactly one record.
+
+  def test_singular_parent_resolves_the_sole_record_in_scope
+    controller = TestableController.new
+    only = Struct.new(:id).new(7)
+
+    assert_equal only, controller.send(:resolve_singular_parent, FakeScope.new([only]), User)
+  end
+
+  # A scope resolving to several means the resource was registered `singular:
+  # true` while its policy still scopes to many. Report THAT, not `sole`'s
+  # "Wanted only one User" — the cause is in a routes file and a policy, and the
+  # person reading the 500 has to be sent to both.
+  def test_singular_parent_reports_the_registration_mistake_not_the_symptom
+    controller = TestableController.new
+    scope = FakeScope.new([Object.new, Object.new, Object.new])
+
+    error = assert_raises(Plutonium::SingularScopeError) do
+      controller.send(:resolve_singular_parent, scope, User)
+    end
+
+    assert_match(/User is registered `singular: true`/, error.message)
+    assert_match(/resolved to 3 records/, error.message)
+    assert_match(/relation_scope/, error.message)
+    assert_match(/without `singular: true`/, error.message)
+  end
+
+  # Minimal stand-in for an ActiveRecord::Relation: `sole` raises exactly what
+  # AR raises, so the rescue under test is the real one.
+  class FakeScope
+    def initialize(records) = @records = records
+
+    def count = @records.size
+
+    def sole
+      raise ActiveRecord::SoleRecordExceeded if @records.size > 1
+      raise ActiveRecord::RecordNotFound if @records.empty?
+      @records.first
+    end
+  end
+
   # Test extraction_record logic for submitted_resource_params
 
   def test_extraction_record_preserves_context_from_existing_record

--- a/test/plutonium/wizard/runner_test.rb
+++ b/test/plutonium/wizard/runner_test.rb
@@ -135,6 +135,33 @@ module Plutonium
         def execute = succeed(:done)
       end
 
+      # --- every step after the first is revealed BY the first step's answer ---
+      # Before `details` is submitted its own condition inputs are blank, so
+      # `details` is the ONLY visible step. Whether the flow is over can therefore
+      # not be decided from the pre-submission visible path.
+      class LateReveal < Plutonium::Wizard::Base
+        step(:details) do
+          attribute :template, :string
+          validates :template, presence: true
+        end
+        step(:setup, condition: -> { data.details.template == "pro" }) do
+          attribute :note, :string
+        end
+        review label: "R", condition: -> { data.details.template == "pro" }
+
+        def execute = succeed(:done)
+      end
+
+      # --- a wizard with no review step: the last step carries fields ---
+      class NoReview < Plutonium::Wizard::Base
+        step(:only) do
+          attribute :name, :string
+          validates :name, presence: true
+        end
+
+        def execute = succeed(data.only.name)
+      end
+
       # --- a branch whose hidden step persisted a real record (save-as-you-go) ---
       # Step `a` chooses a path; `b` is only visible when path == "x" and its
       # `on_submit` creates + persists an Organization; `c` is always visible.
@@ -197,6 +224,55 @@ module Plutonium
         assert_equal %i[a review], @runner.visible_path.map(&:key)
         @runner.advance(:a, {"go" => "yes"})
         assert_equal %i[a b review], build_runner(W).visible_path.map(&:key)
+      end
+
+      # ---- submit (advance-or-finalize) ----
+
+      test "submit advances a step that reveals the steps following it" do
+        result = build_runner(LateReveal).submit(:details, {"template" => "pro"})
+
+        assert_predicate result, :ok?
+        refute_predicate result, :completed?
+        assert_nil result.redirect_step
+        assert_equal :setup, build_runner(LateReveal).current_step.key
+      end
+
+      test "submit finalizes once the posted step reveals nothing after it" do
+        result = build_runner(LateReveal).submit(:details, {"template" => "basic"})
+
+        assert_predicate result, :completed?
+      end
+
+      test "submit stages the last step before finalizing when there is no review" do
+        result = build_runner(NoReview).submit(:only, {"name" => "Zed"})
+
+        assert_predicate result, :completed?
+        assert_equal "Zed", result.value
+      end
+
+      test "submit finalizes on the terminal review step" do
+        runner = build_runner(W)
+        runner.submit(:a, {"go" => "no"})
+
+        assert_predicate build_runner(W).submit(:review, {}), :completed?
+      end
+
+      test "submit returns validation errors without finalizing" do
+        result = build_runner(NoReview).submit(:only, {"name" => ""})
+
+        refute_predicate result, :ok?
+        refute_predicate result, :completed?
+        assert_includes result.errors.keys, :name
+      end
+
+      test "submit honors a goto shortcut instead of finalizing" do
+        runner = build_runner(WithSkippable)
+        runner.submit(:a, {"go" => "yes"})
+        result = build_runner(WithSkippable).submit(:b, {"note" => "n"}, goto: "review")
+
+        assert_predicate result, :ok?
+        refute_predicate result, :completed?
+        assert_equal :review, build_runner(WithSkippable).current_step.key
       end
 
       test "review is always last in the visible path" do

--- a/test/system/org_portal/polymorphic_nested_create_test.rb
+++ b/test/system/org_portal/polymorphic_nested_create_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+# The integration test for this path proves the server infers the parent field.
+# It does not render anything: an ActionDispatch::IntegrationTest never opens a
+# browser, so a form that will not submit — a stray required input, a Stimulus
+# controller that throws on connect — would sail through it.
+#
+# This drives the same nesting in Chrome, through the form a user actually gets,
+# and fails on any severe console error along the way.
+class OrgPortal::PolymorphicNestedCreateTest < ApplicationSystemTestCase
+  setup do
+    @org = create_organization!
+    @user = create_user!
+    create_membership!(organization: @org, user: @user)
+    @post = create_post!(user: @user, organization: @org)
+  end
+
+  test "creates a comment through a polymorphic nesting with no inverse_of" do
+    visit "/org/#{@org.to_param}/blogging/posts/#{@post.id}/nested_noninverse_comments/new"
+    fill_in "login", with: @user.email
+    fill_in "password", with: "password123"
+    click_button "Login"
+
+    assert_selector "form", wait: 10
+
+    # Drain the console buffer before the part under test. The browser session is
+    # shared across the system suite, so `logs.get` otherwise returns whatever
+    # earlier tests logged — and the login page this test just walked through
+    # has its own unrelated Stimulus error ("Missing target element \"checkbox\"
+    # for \"password-visibility\""). Neither says anything about the nesting, and
+    # folding them in makes the assertion below fail depending on run order.
+    page.driver.browser.logs.get(:browser)
+
+    fill_in "Body", with: "Typed into the browser"
+
+    # Comment belongs_to :user, so the form will not submit without one — and a
+    # validation re-render still shows the typed body, which would make a naive
+    # text assertion pass on a comment that was never created.
+    #
+    # The select is driven through its slim-select widget rather than by name:
+    # the native element is display:none and aria-hidden, so Capybara cannot
+    # reach it, and reaching past the widget would not be what a user does. The
+    # option is matched on the user's `to_label` ("User #1"), which is what the
+    # widget renders — the email only exists on the model.
+    find(".ss-main").click
+    find(".ss-option", text: @user.to_label, match: :first, wait: 10).click
+    click_button "Create Comment"
+
+    # Wait on the flash, not on the body text: the body is also on screen in the
+    # form the user just left, so asserting it can pass mid-navigation and read
+    # the database before the create has landed. The flash exists only after the
+    # redirect, so it is the signal that the write is done.
+    assert_text "Comment was successfully created", wait: 10
+    assert_text "Typed into the browser"
+
+    comment = Comment.order(:id).last
+    assert_equal @post.id, comment.commentable_id
+    # The half that goes missing when the polymorphic reflection is skipped.
+    assert_equal @post.class.polymorphic_name, comment.commentable_type
+    assert_equal @user.id, comment.user_id
+
+    severe = page.driver.browser.logs.get(:browser).select { |entry| entry.level == "SEVERE" }
+    assert_empty severe.map(&:message), "browser console reported errors during the nested create"
+  end
+end


### PR DESCRIPTION
## The bug

`Driving#advance_or_finalize` asked *"is this the last visible step?"* **before** staging the submission. Every `condition:` is evaluated against `data`, so a step gated on an answer from the step being submitted is still hidden at POST time. Two shapes broke:

- **Late-reveal wizards** — the first step's answer reveals the rest. The visible path was `[details]`, so the first POST finalized; `finalize` found `details` unsubmitted and PRG'd back to it. Forever. The revealed steps were unreachable and no run was ever written.
- **Wizards with no `review` step** — the last field step finalized *without staging its params*, silently dropping them before `execute`.

It also disagreed with the UI: `render_nav` shows Finish only on the review step, never on a field step that merely happens to be last right now.

## The fix

The decision moves into `Runner#submit`, which stages *then* looks:

```ruby
def submit(step_key, params, goto: nil)
  step = step_for(step_key)
  return finalize if step&.review?      # no fields to stage

  result = advance(step_key, params, goto:)
  return result unless result.ok?
  return result if @state.current_step.present?   # a next step survived
  finalize
end
```

`advance` recomputes `visible_path` against the freshly staged data, so a nil cursor afterwards genuinely means nothing follows. The `goto:` "Save & review" shortcut keeps working because it leaves a cursor. `driving.rb` becomes a one-line delegation.

**Behaviour change:** a conditional `review` is now supported — when it branches out, that POST is the terminal one and runs `execute`. Previously the workaround was to keep `review` unconditional.

## Tests

- 6 unit tests in `test/plutonium/wizard/runner_test.rb` — late-reveal advance, late-reveal finalize, no-review staging, review short-circuit, validation errors, `goto:`.
- 3 integration tests in `test/integration/admin_portal/wizard_late_reveal_test.rb` against a new dummy `LateRevealWizard` at `/admin/late-reveal`. All three fail without the fix (verified by stashing the lib change — reproduces the exact bounce-back-to-`details`).
- Full suite on rails-8.1: **2836 runs, 7085 assertions, 0 failures**. `standardrb` clean.

Also documents the behaviour in the wizard skill's Branching section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDJ4A3cWgH5H3EvYKStqPv


---

## Also in this PR: one arity rule for proc-valued options

Proc-valued field/input options (`feat(ui)`, #87) are now resolved across the **whole** form DSL — `field`, `input`, `section`/`ungrouped`, `structured_input` and nested inputs — under a single rule, on resource, interaction and wizard forms alike:

- **`-> { … }`** is called as-is and keeps its own binding. It means what it reads like where you wrote it; nothing rebinds `self`.
- **`->(form) { … }`** is handed the form — `object`, `params`, view helpers. On a wizard step, `form.wizard` is the run.

This adopts the semantics `choices:` has always had (phlexi-form resolves it with a plain `.call`), rather than replacing them — so the older, more widely used behaviour is the one that survives. `Form::Wizard` no longer overrides the receiver, so there are no exceptions.

`condition:` is unchanged. It is not an option: it asks "should this render *here, now*?", so it always runs *against* whatever is rendering — the form for a field, the component for a `column`/`display`, the **wizard** for a step (evaluated before any form exists), a condition context for an action. Documented under [Definition › `condition:` is not an option].

### Migration

Only **section** options are affected — `label:`, `description:`, `collapsible:`, `collapsed:` inside a `form_layout` block. They previously took a zero-argument proc evaluated against the form; they now follow the shared rule, and a `form_layout` block is evaluated against the layout builder, so a bare `object` no longer resolves:

```ruby
 form_layout do
   section :advanced, :seo_title, :notes,
     collapsible: true,
-    collapsed: -> { object.persisted? },
+    collapsed: ->(form) { form.object.persisted? },
     condition: -> { object.requires_shipping? }   # unchanged — conditions keep their receiver
   end
 end
```

Fails loudly with `NameError`, never silently. `columns:` is literal-only and unaffected. Field/input options, including `choices:`, are unaffected.

## Other fixes in this PR

- Nested routes now carry their registration key, so the parent class and association are read from the route instead of parsed out of the URL — which is what lets a `singular: true` resource act as a parent (it contributes no id segment).
- New `Plutonium::SingularScopeError`: a `singular: true` resource whose authorized scope resolves to more than one record now reports the registration/policy mismatch instead of a bare `ActiveRecord::SoleRecordExceeded`.
- Polymorphic nestings resolve the parent field without an `inverse_of`, setting both the id and the type.
- Nested collection URLs for association names that singularize to themselves (`comment_series`) match Rails' `_index` suffix.

## Verification

rails-7 / rails-8.0 / rails-8.1: 2740 tests, 0 failures, 0 errors. System suite: 14 tests, 0 failures. `standardrb` clean.

BREAKING CHANGE: `form_layout` section options (`label:`, `description:`, `collapsible:`, `collapsed:`) now follow the same arity rule as every other proc-valued option. A zero-argument proc keeps its own binding instead of being evaluated against the form, so `collapsed: -> { object.persisted? }` must become `collapsed: ->(form) { form.object.persisted? }`. Raises NameError rather than failing silently. `condition:` and `columns:` are unchanged.
