### PR TITLE
feat: eager-load what a collection is about to render

### DIFF
--- a/.claude/skills/plutonium-behavior/SKILL.md
+++ b/.claude/skills/plutonium-behavior/SKILL.md
@@ -158,6 +158,16 @@ def filtered_resource_collection
 end
 ```
 
+**N+1 on an index.** A table/grid/kanban that renders an association (`column :author`) queries once per row unless the collection is eager-loaded. Fix it here — `super` preserves scoping, search, filters and sorting:
+
+```ruby
+def filtered_resource_collection = super.includes(:user, :organization)
+```
+
+Measured on a real index: without it, queries grow `7 + rows`; with it, flat at 9 regardless of page size. Use the policy's `relation_scope` instead when the association is read from several actions (show, export, typeahead), not just the listing. Suggest [goldiloader](https://github.com/salsify/goldiloader) when hand-maintained `includes` lists keep rotting — it eager-loads on traversal, so it tracks whatever the definition renders. Note it assumes uniform access across the collection and is a sharp edge for ordered+limited `has_one`.
+
+**Don't overstate it on SQLite.** Measured query-layer cost there is ~4–10× (2.78ms vs 0.64ms at 20 rows; 14.97 vs 1.40 at 100) — real, because the dominant per-query cost is ActiveRecord's Ruby-side work, not the round trip. But end to end that is ~6ms of a ~45ms request at 20 rows, i.e. noise. Don't chase N+1 on a small SQLite listing; do fix it for large pages, several associations per row, or a networked database. Never claim a local SQLite timing proves a page is fast on Postgres — the query count is identical, only the per-query cost changed.
+
 ### Presentation hooks
 
 Control whether parent / scoped-entity fields appear in forms and displays. Defaults are `false` (hidden, since they're inferred from the URL/portal).

--- a/.claude/skills/plutonium-behavior/SKILL.md
+++ b/.claude/skills/plutonium-behavior/SKILL.md
@@ -158,15 +158,9 @@ def filtered_resource_collection
 end
 ```
 
-**N+1 on an index.** A table/grid/kanban that renders an association (`column :author`) queries once per row unless the collection is eager-loaded. Fix it here — `super` preserves scoping, search, filters and sorting:
+**Don't add eager loading unprompted.** Which associations a page renders is decided by the definition, so an `includes` list written now is a guess that goes stale when a column is added. Adding one is a performance change the user didn't ask for.
 
-```ruby
-def filtered_resource_collection = super.includes(:user, :organization)
-```
-
-Measured on a real index: without it, queries grow `7 + rows`; with it, flat at 9 regardless of page size. Use the policy's `relation_scope` instead when the association is read from several actions (show, export, typeahead), not just the listing. Suggest [goldiloader](https://github.com/salsify/goldiloader) when hand-maintained `includes` lists keep rotting — it eager-loads on traversal, so it tracks whatever the definition renders. Note it assumes uniform access across the collection and is a sharp edge for ordered+limited `has_one`.
-
-**Don't overstate it on SQLite.** Measured query-layer cost there is ~4–10× (2.78ms vs 0.64ms at 20 rows; 14.97 vs 1.40 at 100) — real, because the dominant per-query cost is ActiveRecord's Ruby-side work, not the round trip. But end to end that is ~6ms of a ~45ms request at 20 rows, i.e. noise. Don't chase N+1 on a small SQLite listing; do fix it for large pages, several associations per row, or a networked database. Never claim a local SQLite timing proves a page is fast on Postgres — the query count is identical, only the per-query cost changed.
+When a user actually reports a slow index or an N+1: suggest [goldiloader](https://github.com/salsify/goldiloader) first — it eager-loads on traversal, so it tracks whatever the definition renders and needs no list to maintain. Only hand-write `def filtered_resource_collection = super.includes(...)` if they decline the gem, and use the policy's `relation_scope` instead when the association is also read on show/export/typeahead. Full detail: [Guides › Performance](/guides/performance).
 
 ### Presentation hooks
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -123,7 +123,7 @@ export default defineConfig(withMermaid({
           text: "Quality",
           items: [
             { text: "Testing", link: "/guides/testing" },
-            { text: "Performance (N+1)", link: "/guides/performance" },
+            { text: "Performance", link: "/guides/performance" },
             { text: "Troubleshooting", link: "/guides/troubleshooting" },
           ]
         }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -123,6 +123,8 @@ export default defineConfig(withMermaid({
           text: "Quality",
           items: [
             { text: "Testing", link: "/guides/testing" },
+            { text: "Performance (N+1)", link: "/guides/performance" },
+            { text: "Troubleshooting", link: "/guides/troubleshooting" },
           ]
         }
       ],

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -34,7 +34,7 @@ aside: false
     ]},
     { group: 'Quality', items: [
       { name: 'Testing', link: '/plutonium-core/guides/testing' },
-      { name: 'Performance (N+1)', desc: 'Eager loading for index pages.', link: '/plutonium-core/guides/performance' },
+      { name: 'Performance', desc: 'N+1 queries and eager loading.', link: '/plutonium-core/guides/performance' },
       { name: 'Troubleshooting', link: '/plutonium-core/guides/troubleshooting' },
     ]},
   ]"

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -34,6 +34,7 @@ aside: false
     ]},
     { group: 'Quality', items: [
       { name: 'Testing', link: '/plutonium-core/guides/testing' },
+      { name: 'Performance (N+1)', desc: 'Eager loading for index pages.', link: '/plutonium-core/guides/performance' },
       { name: 'Troubleshooting', link: '/plutonium-core/guides/troubleshooting' },
     ]},
   ]"

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,0 +1,128 @@
+# Performance: N+1 Queries
+
+Plutonium renders association values for you — a `display :author`, a table `column :organization`, a grid or kanban card that shows a related name. Each of those reads an association off a record, and if the collection wasn't loaded with that association, Rails fetches it one record at a time.
+
+That is the N+1 problem, and index pages are where it shows up first: one query for the page of records, then one more per row per association.
+
+## Seeing it
+
+It is not subtle once you count. This is a real Plutonium index (`Blogging::Post`, whose table shows `user` and `organization`), counting `sql.active_record` events per request:
+
+| Rows on the page | Total queries | Queries against `users` |
+|---|---|---|
+| 1 | 8 | 4 |
+| 5 | 12 | 8 |
+| 15 | 22 | 18 |
+
+Queries grow **one per row**. At the default page size that is a few dozen; raise the page size and it grows with it.
+
+The cheapest way to watch this in your own app is the query log — `tail -f log/development.log` and reload an index. A wall of near-identical `SELECT * FROM users WHERE id = ?` lines is the signature. [`bullet`](https://github.com/flyerhzm/bullet) will flag them for you in development if you'd rather be told than look.
+
+## Does it actually matter on SQLite?
+
+Less than the folklore says, but not nothing — and "SQLite makes N+1 free" is not what the numbers show. Measured against this repo's own dummy app on SQLite, timing only the query layer (fetch N posts, read `post.user` on each):
+
+| Rows | N+1 | `includes` | Ratio |
+|---|---|---|---|
+| 20 | 2.78 ms | 0.64 ms | **4.4×** |
+| 100 | 14.97 ms | 1.40 ms | **10.7×** |
+| 200 | 24.83 ms | 2.41 ms | **10.3×** |
+
+An order of magnitude, with no network anywhere. The reason is that most of the per-query cost isn't the database at all — it's ActiveRecord's Ruby-side work: building the relation, dispatching, instantiating objects, type-casting columns. That cost is adapter-independent, which is why removing the round trip doesn't rescue you.
+
+What SQLite *does* change is whether that difference is worth your attention, because the query layer is a small slice of a real request. The same pages, timed end to end through the full stack:
+
+| Rows | N+1 | `includes` |
+|---|---|---|
+| 20 | 48.2 ms | 42.3 ms |
+| 100 | 161.3 ms | 132.5 ms |
+
+At 20 rows the win is a couple of milliseconds out of ~45 — at or below run-to-run noise, and invisible to a user. At 100 rows it is ~18% of the request. Rendering dominates either way.
+
+So a fair reading:
+
+- **N+1 on SQLite is not a crisis.** The advice that it is comes from network-attached databases, where each of those N queries is a round trip and the same page falls off a cliff. Carrying that alarm over to SQLite is miscalibrated.
+- **It is still ~10× the query cost**, and it grows with page size while eager loading stays flat. It is a real cost that happens to be small at small N.
+- **It is not "recommended".** There is no upside to the extra queries; there is only a threshold below which the upside of fixing them is too small to chase.
+
+::: tip A usable rule
+Don't hunt N+1s on a 20-row admin listing backed by SQLite — you will spend more time maintaining `includes` lists than you save. Do fix them when page size is large, when several associations render per row, or when you deploy on Postgres/MySQL, where the same access pattern costs a round trip each and the numbers above get much worse.
+
+And don't read a local SQLite timing as proof a page is fast on a networked database — the query count is identical, only the per-query cost changed.
+:::
+
+## Fixing it: eager-load the collection
+
+### For an index page — `filtered_resource_collection`
+
+The index collection goes through the [`filtered_resource_collection`](/reference/behavior/controllers#index-query-hook) controller hook. Override it and add the associations the page renders:
+
+```ruby
+class Blogging::PostsController < ::ResourceController
+  private
+
+  def filtered_resource_collection
+    super.includes(:user, :organization)
+  end
+end
+```
+
+`super` keeps authorization scoping, search, filters, scopes and sorting intact — you are only adding the eager load.
+
+Same measurement as above, with that override in place:
+
+| Rows on the page | Total queries | Queries against `users` |
+|---|---|---|
+| 1 | 9 | 4 |
+| 5 | 9 | 4 |
+| 15 | 9 | 4 |
+
+**Flat.** One extra query up front buys a constant, and the page stops caring how many rows it shows.
+
+### For every read — `relation_scope`
+
+`filtered_resource_collection` only covers the index. If a show page renders a `has_many`, or an association is read in several places, put the eager load in the policy's [`relation_scope`](/reference/behavior/policies) instead so every authorized read gets it:
+
+```ruby
+class Blogging::PostPolicy < ResourcePolicy
+  relation_scope do |relation|
+    default_relation_scope(relation).includes(:user, :organization)
+  end
+end
+```
+
+Remember the rule from [Behavior › Policies](/reference/behavior/policies): a custom `relation_scope` **must** end up calling `default_relation_scope`, or scoping is silently dropped.
+
+::: tip Which one?
+`filtered_resource_collection` is the surgical choice — it eager-loads only for the listing that needs it. `relation_scope` is broader and will also eager-load for a single-record `show`, a typeahead lookup, or an export, where the join may be wasted. Start with the controller hook; reach for the policy when the same association is read from several actions.
+:::
+
+## Fixing it: let a gem do it
+
+Hand-maintained `includes` lists rot. A column gets added to a definition, nobody updates the controller, and the N+1 comes back silently — nothing fails, the page just gets slower.
+
+[**Goldiloader**](https://github.com/salsify/goldiloader) removes the bookkeeping. It hooks association traversal: the first time you read `post.user` on a record that came from a collection, it loads that association for *every* record in the collection with a single `WHERE id IN (…)`, instead of one query per record. No `includes` anywhere.
+
+```ruby
+# Gemfile
+gem "goldiloader"
+```
+
+That is usually all of it — it works out of the box and needs no per-model configuration. It suits Plutonium well, because the associations a page reads are decided by the definition at render time, which is exactly the thing an up-front `includes` list has to guess.
+
+Know the trade-offs before you add it:
+
+- **It assumes uniform access.** Reading an association on one record eager-loads it for the whole collection. When only one row actually needs it, that is over-fetching.
+- **`has_one` with an order and a limit is a sharp edge.** Eager loading makes `LIMIT 1` apply to the whole query rather than per parent, so it can pull far more rows than expected.
+- **It disables itself** for associations declared with `limit`, `offset`, or `finder_sql`.
+- **Opting out** is per-query (`Post.all.auto_include(false)`), per-association (`has_many :comments, -> { auto_include(false) }`), or globally (`Goldiloader.globally_enabled = false`, then re-enable in `Goldiloader.enabled { }` blocks).
+
+[`ar_lazy_preload`](https://github.com/DmitryTsepelev/ar_lazy_preload) is the alternative, with the same idea reached differently — it preloads lazily on first access, and `ArLazyPreload.config.auto_preload = true` makes it automatic everywhere. Its own docs warn that enabling `auto_preload` on an existing app can surface edge cases, so introduce it deliberately rather than as a default.
+
+Neither gem is a substitute for knowing what your page queries. They are a good default that stops the common case from regressing; a genuinely hot page still deserves an explicit `includes` and a look at the log.
+
+## Beyond eager loading
+
+- **Page size.** N+1 cost scales with rows per page. See [Resource › Query](/reference/resource/query) for pagination options.
+- **Search fallback.** A resource with no `search` block falls back to a leading-wildcard `LIKE`, which cannot use a b-tree index and degrades past a few thousand rows. Write an explicit `search` block backed by a trigram or full-text index — see [Query › Search](/reference/resource/query#search).
+- **`count` on large tables.** Pagination needs a count; on very large Postgres tables an exact `COUNT(*)` is itself a slow query.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -14,11 +14,38 @@ tail -f log/development.log
 
 The cost matters most where each query is a network round trip. On Postgres or MySQL an index page can spend most of its time waiting; on SQLite the same page is cheaper, though the query count is identical. Either way the count grows with page size, so a listing that is fine at 20 rows may not be at 200.
 
-## Eager loading
+## Index pages preload themselves
+
+Index pages already eager-load the associations and attachments their columns render. The column set comes from the policy, so the framework knows it before the collection loads and can preload exactly those. Nothing to declare, and nothing to keep in step when a column is added or removed.
+
+It covers `belongs_to` and `has_one`, and attachments on both ActiveStorage and Shrine. `has_many` is excluded: preloading one to render a count loads every child row, which loses to a counter cache.
+
+Turn it off globally:
+
+```ruby
+# config/initializers/plutonium.rb
+Plutonium.configure do |config|
+  config.auto_eager_load_index = false
+end
+```
+
+Or per resource:
+
+```ruby
+class PostsController < ::ResourceController
+  private
+
+  def auto_eager_load_index? = false
+end
+```
+
+## Eager loading by hand
+
+Other actions, and anything the framework can't see — an association read inside a custom column block, or one rendered on a show page — still need declaring.
 
 ### One listing
 
-Override `filtered_resource_collection` and add the associations that page renders. `super` keeps authorization scoping, search, filters, scopes and sorting:
+Override `filtered_resource_collection`. `super` keeps authorization scoping, search, filters, scopes and sorting:
 
 ```ruby
 class PostsController < ::ResourceController
@@ -32,7 +59,7 @@ See [Behavior › Controllers](/reference/behavior/controllers#index-query-hook)
 
 ### Everywhere
 
-`filtered_resource_collection` only covers the index. When an association is also read on a show page, an export or a typeahead, put it in the policy's `relation_scope` instead:
+When an association is read on a show page, an export or a typeahead, put it in the policy's `relation_scope`:
 
 ```ruby
 class PostPolicy < ResourcePolicy
@@ -46,9 +73,7 @@ A custom `relation_scope` must still call `default_relation_scope`, or scoping i
 
 ## Automatic eager loading
 
-Which associations a page renders is decided by the definition, so a hand-written `includes` list is a guess that goes stale when a column is added.
-
-[Goldiloader](https://github.com/salsify/goldiloader) removes the bookkeeping. It hooks association traversal: reading `post.author` on a record from a collection loads that association for the whole collection in one query. No `includes` anywhere.
+For the cases above that the framework can't resolve for you, [Goldiloader](https://github.com/salsify/goldiloader) removes the bookkeeping. It hooks association traversal: reading `post.author` on a record from a collection loads that association for the whole collection in one query. No `includes` anywhere.
 
 ```ruby
 # Gemfile

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -14,9 +14,11 @@ tail -f log/development.log
 
 The cost matters most where each query is a network round trip. On Postgres or MySQL an index page can spend most of its time waiting; on SQLite the same page is cheaper, though the query count is identical. Either way the count grows with page size, so a listing that is fine at 20 rows may not be at 200.
 
-## Index pages preload themselves
+## Collections preload themselves
 
-Index pages already eager-load the associations and attachments their columns render. The column set comes from the policy, so the framework knows it before the collection loads and can preload exactly those. Nothing to declare, and nothing to keep in step when a column is added or removed.
+Index pages, kanban boards and CSV exports already eager-load the associations and attachments they render. The field set comes from the policy, so the framework knows it before the collection loads and can preload exactly those. Nothing to declare, and nothing to keep in step when a field is added or removed.
+
+Each rendering passes its own field set, because they differ: the index renders its permitted attributes, an export renders `permitted_attributes_for_export`, and a kanban card renders its `card_fields`.
 
 It covers `belongs_to` and `has_one`, and attachments on both ActiveStorage and Shrine. `has_many` is excluded: preloading one to render a count loads every child row, which loses to a counter cache.
 
@@ -41,7 +43,7 @@ end
 
 ## Eager loading by hand
 
-Other actions, and anything the framework can't see — an association read inside a custom column block, or one rendered on a show page — still need declaring.
+Anything the framework can't see still needs declaring: an association read inside a custom column block, or one rendered on a show page.
 
 ### One listing
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,128 +1,70 @@
 # Performance: N+1 Queries
 
-Plutonium renders association values for you — a `display :author`, a table `column :organization`, a grid or kanban card that shows a related name. Each of those reads an association off a record, and if the collection wasn't loaded with that association, Rails fetches it one record at a time.
+Plutonium renders association values for you: a `display :author`, a table `column :organization`, a grid or kanban card showing a related name. Reading an association off a record that wasn't loaded with it costs a query, so an index page runs one query for the page plus one per row per association.
 
-That is the N+1 problem, and index pages are where it shows up first: one query for the page of records, then one more per row per association.
+## Spotting it
 
-## Seeing it
+Tail the log and reload an index. A run of near-identical `SELECT * FROM users WHERE id = ?` lines, one per row, is the signature.
 
-It is not subtle once you count. This is a real Plutonium index (`Blogging::Post`, whose table shows `user` and `organization`), counting `sql.active_record` events per request:
+```bash
+tail -f log/development.log
+```
 
-| Rows on the page | Total queries | Queries against `users` |
-|---|---|---|
-| 1 | 8 | 4 |
-| 5 | 12 | 8 |
-| 15 | 22 | 18 |
+[`bullet`](https://github.com/flyerhzm/bullet) reports them in development if you'd rather be told than look.
 
-Queries grow **one per row**. At the default page size that is a few dozen; raise the page size and it grows with it.
+The cost matters most where each query is a network round trip. On Postgres or MySQL an index page can spend most of its time waiting; on SQLite the same page is cheaper, though the query count is identical. Either way the count grows with page size, so a listing that is fine at 20 rows may not be at 200.
 
-The cheapest way to watch this in your own app is the query log — `tail -f log/development.log` and reload an index. A wall of near-identical `SELECT * FROM users WHERE id = ?` lines is the signature. [`bullet`](https://github.com/flyerhzm/bullet) will flag them for you in development if you'd rather be told than look.
+## Eager loading
 
-## Does it actually matter on SQLite?
+### One listing
 
-Less than the folklore says, but not nothing — and "SQLite makes N+1 free" is not what the numbers show. Measured against this repo's own dummy app on SQLite, timing only the query layer (fetch N posts, read `post.user` on each):
-
-| Rows | N+1 | `includes` | Ratio |
-|---|---|---|---|
-| 20 | 2.78 ms | 0.64 ms | **4.4×** |
-| 100 | 14.97 ms | 1.40 ms | **10.7×** |
-| 200 | 24.83 ms | 2.41 ms | **10.3×** |
-
-An order of magnitude, with no network anywhere. The reason is that most of the per-query cost isn't the database at all — it's ActiveRecord's Ruby-side work: building the relation, dispatching, instantiating objects, type-casting columns. That cost is adapter-independent, which is why removing the round trip doesn't rescue you.
-
-What SQLite *does* change is whether that difference is worth your attention, because the query layer is a small slice of a real request. The same pages, timed end to end through the full stack:
-
-| Rows | N+1 | `includes` |
-|---|---|---|
-| 20 | 48.2 ms | 42.3 ms |
-| 100 | 161.3 ms | 132.5 ms |
-
-At 20 rows the win is a couple of milliseconds out of ~45 — at or below run-to-run noise, and invisible to a user. At 100 rows it is ~18% of the request. Rendering dominates either way.
-
-So a fair reading:
-
-- **N+1 on SQLite is not a crisis.** The advice that it is comes from network-attached databases, where each of those N queries is a round trip and the same page falls off a cliff. Carrying that alarm over to SQLite is miscalibrated.
-- **It is still ~10× the query cost**, and it grows with page size while eager loading stays flat. It is a real cost that happens to be small at small N.
-- **It is not "recommended".** There is no upside to the extra queries; there is only a threshold below which the upside of fixing them is too small to chase.
-
-::: tip A usable rule
-Don't hunt N+1s on a 20-row admin listing backed by SQLite — you will spend more time maintaining `includes` lists than you save. Do fix them when page size is large, when several associations render per row, or when you deploy on Postgres/MySQL, where the same access pattern costs a round trip each and the numbers above get much worse.
-
-And don't read a local SQLite timing as proof a page is fast on a networked database — the query count is identical, only the per-query cost changed.
-:::
-
-## Fixing it: eager-load the collection
-
-### For an index page — `filtered_resource_collection`
-
-The index collection goes through the [`filtered_resource_collection`](/reference/behavior/controllers#index-query-hook) controller hook. Override it and add the associations the page renders:
+Override `filtered_resource_collection` and add the associations that page renders. `super` keeps authorization scoping, search, filters, scopes and sorting:
 
 ```ruby
-class Blogging::PostsController < ::ResourceController
+class PostsController < ::ResourceController
   private
 
-  def filtered_resource_collection
-    super.includes(:user, :organization)
-  end
+  def filtered_resource_collection = super.includes(:author, :category)
 end
 ```
 
-`super` keeps authorization scoping, search, filters, scopes and sorting intact — you are only adding the eager load.
+See [Behavior › Controllers](/reference/behavior/controllers#index-query-hook).
 
-Same measurement as above, with that override in place:
+### Everywhere
 
-| Rows on the page | Total queries | Queries against `users` |
-|---|---|---|
-| 1 | 9 | 4 |
-| 5 | 9 | 4 |
-| 15 | 9 | 4 |
-
-**Flat.** One extra query up front buys a constant, and the page stops caring how many rows it shows.
-
-### For every read — `relation_scope`
-
-`filtered_resource_collection` only covers the index. If a show page renders a `has_many`, or an association is read in several places, put the eager load in the policy's [`relation_scope`](/reference/behavior/policies) instead so every authorized read gets it:
+`filtered_resource_collection` only covers the index. When an association is also read on a show page, an export or a typeahead, put it in the policy's `relation_scope` instead:
 
 ```ruby
-class Blogging::PostPolicy < ResourcePolicy
+class PostPolicy < ResourcePolicy
   relation_scope do |relation|
-    default_relation_scope(relation).includes(:user, :organization)
+    default_relation_scope(relation).includes(:author, :category)
   end
 end
 ```
 
-Remember the rule from [Behavior › Policies](/reference/behavior/policies): a custom `relation_scope` **must** end up calling `default_relation_scope`, or scoping is silently dropped.
+A custom `relation_scope` must still call `default_relation_scope`, or scoping is dropped. See [Behavior › Policies](/reference/behavior/policies).
 
-::: tip Which one?
-`filtered_resource_collection` is the surgical choice — it eager-loads only for the listing that needs it. `relation_scope` is broader and will also eager-load for a single-record `show`, a typeahead lookup, or an export, where the join may be wasted. Start with the controller hook; reach for the policy when the same association is read from several actions.
-:::
+## Automatic eager loading
 
-## Fixing it: let a gem do it
+Which associations a page renders is decided by the definition, so a hand-written `includes` list is a guess that goes stale when a column is added.
 
-Hand-maintained `includes` lists rot. A column gets added to a definition, nobody updates the controller, and the N+1 comes back silently — nothing fails, the page just gets slower.
-
-[**Goldiloader**](https://github.com/salsify/goldiloader) removes the bookkeeping. It hooks association traversal: the first time you read `post.user` on a record that came from a collection, it loads that association for *every* record in the collection with a single `WHERE id IN (…)`, instead of one query per record. No `includes` anywhere.
+[Goldiloader](https://github.com/salsify/goldiloader) removes the bookkeeping. It hooks association traversal: reading `post.author` on a record from a collection loads that association for the whole collection in one query. No `includes` anywhere.
 
 ```ruby
 # Gemfile
 gem "goldiloader"
 ```
 
-That is usually all of it — it works out of the box and needs no per-model configuration. It suits Plutonium well, because the associations a page reads are decided by the definition at render time, which is exactly the thing an up-front `includes` list has to guess.
+It works without per-model configuration. Before adding it:
 
-Know the trade-offs before you add it:
+- It assumes uniform access. Reading an association on one record loads it for every record, which over-fetches when only one row needed it.
+- `has_one` with an order and a limit is a sharp edge: eager loading applies `LIMIT 1` to the whole query rather than per parent.
+- It disables itself for associations declared with `limit`, `offset` or `finder_sql`.
+- Opt out per query (`Post.all.auto_include(false)`), per association (`has_many :comments, -> { auto_include(false) }`) or globally (`Goldiloader.globally_enabled = false`).
 
-- **It assumes uniform access.** Reading an association on one record eager-loads it for the whole collection. When only one row actually needs it, that is over-fetching.
-- **`has_one` with an order and a limit is a sharp edge.** Eager loading makes `LIMIT 1` apply to the whole query rather than per parent, so it can pull far more rows than expected.
-- **It disables itself** for associations declared with `limit`, `offset`, or `finder_sql`.
-- **Opting out** is per-query (`Post.all.auto_include(false)`), per-association (`has_many :comments, -> { auto_include(false) }`), or globally (`Goldiloader.globally_enabled = false`, then re-enable in `Goldiloader.enabled { }` blocks).
+[`ar_lazy_preload`](https://github.com/DmitryTsepelev/ar_lazy_preload) takes the same idea from the other end, preloading lazily on first access, with `ArLazyPreload.config.auto_preload = true` for automatic behaviour everywhere. Its docs warn that enabling it on an existing app can surface edge cases.
 
-[`ar_lazy_preload`](https://github.com/DmitryTsepelev/ar_lazy_preload) is the alternative, with the same idea reached differently — it preloads lazily on first access, and `ArLazyPreload.config.auto_preload = true` makes it automatic everywhere. Its own docs warn that enabling `auto_preload` on an existing app can surface edge cases, so introduce it deliberately rather than as a default.
+## Related
 
-Neither gem is a substitute for knowing what your page queries. They are a good default that stops the common case from regressing; a genuinely hot page still deserves an explicit `includes` and a look at the log.
-
-## Beyond eager loading
-
-- **Page size.** N+1 cost scales with rows per page. See [Resource › Query](/reference/resource/query) for pagination options.
-- **Search fallback.** A resource with no `search` block falls back to a leading-wildcard `LIKE`, which cannot use a b-tree index and degrades past a few thousand rows. Write an explicit `search` block backed by a trigram or full-text index — see [Query › Search](/reference/resource/query#search).
-- **`count` on large tables.** Pagination needs a count; on very large Postgres tables an exact `COUNT(*)` is itself a slow query.
+- **Search fallback.** A resource with no `search` block falls back to a leading-wildcard `LIKE`, which cannot use a b-tree index. Write an explicit `search` block for large tables — see [Resource › Query](/reference/resource/query#search).
+- **Page size.** Query cost scales with rows per page.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -20,14 +20,14 @@ Index pages, kanban boards and CSV exports already eager-load the associations a
 
 Each rendering passes its own field set, because they differ: the index renders its permitted attributes, an export renders `permitted_attributes_for_export`, and a kanban card renders its `card_fields`.
 
-It covers `belongs_to` and `has_one`, and attachments on both ActiveStorage and Shrine. `has_many` is excluded: preloading one to render a count loads every child row, which loses to a counter cache.
+It covers every association kind — `belongs_to`, `has_one`, `has_many` — and attachments on both ActiveStorage and Shrine.
 
 Turn it off globally:
 
 ```ruby
 # config/initializers/plutonium.rb
 Plutonium.configure do |config|
-  config.auto_eager_load_index = false
+  config.auto_eager_load_collections = false
 end
 ```
 
@@ -37,7 +37,7 @@ Or per resource:
 class PostsController < ::ResourceController
   private
 
-  def auto_eager_load_index? = false
+  def auto_eager_load_collections? = false
 end
 ```
 

--- a/docs/reference/behavior/controllers.md
+++ b/docs/reference/behavior/controllers.md
@@ -108,13 +108,13 @@ def filtered_resource_collection
 end
 ```
 
-This is also where you eager-load associations the index renders, which is the usual cure for an N+1 on a listing — call `super` to keep scoping, search, filters and sorting, and add the `includes`:
+Also where you eager-load associations the index renders. `super` keeps scoping, search, filters and sorting:
 
 ```ruby
-def filtered_resource_collection = super.includes(:user, :organization)
+def filtered_resource_collection = super.includes(:author, :category)
 ```
 
-See [Guides › Performance (N+1)](/guides/performance).
+See [Guides › Performance](/guides/performance).
 
 ### Presentation hooks
 

--- a/docs/reference/behavior/controllers.md
+++ b/docs/reference/behavior/controllers.md
@@ -108,6 +108,14 @@ def filtered_resource_collection
 end
 ```
 
+This is also where you eager-load associations the index renders, which is the usual cure for an N+1 on a listing — call `super` to keep scoping, search, filters and sorting, and add the `includes`:
+
+```ruby
+def filtered_resource_collection = super.includes(:user, :organization)
+```
+
+See [Guides › Performance (N+1)](/guides/performance).
+
 ### Presentation hooks
 
 Control whether parent / scoped-entity fields appear in forms and displays. Defaults are `false` (hidden, since they're inferred from the URL/portal).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,7 +38,7 @@ Loads the baseline defaults for a given framework version. Call this first; late
 | `enable_hotreload` | `true` in `development` env | Hot-reload Plutonium components on change. |
 | `shell` | `:modern` | Chrome style: `:modern` (topbar + icon rail), `:plain` (topbar, no icon rail), or `:classic` (legacy header + sidebar, only for upgrades). See [Layouts](./ui/layouts). |
 | `navii_host_url` | `"https://api.navii.dev"` | Host of the [Navii](https://navii.dev) avatar service used by [`Avatar`](./ui/components#avatar). The component appends `/avatar/:seed`. Repoint to self-host or proxy. |
-| `auto_eager_load_index` | `true` | Index pages preload the associations and attachments their columns render. Set `false` to disable globally, or override `auto_eager_load_index?` in a controller. See [Performance](/guides/performance). |
+| `auto_eager_load_index` | `true` | Index pages, kanban boards and CSV exports preload the associations and attachments they render. Set `false` to disable globally, or override `auto_eager_load_index?` in a controller. See [Performance](/guides/performance). |
 | `assets.logo` | `"plutonium.png"` | Brand logo asset. See [Assets](./ui/assets). |
 | `assets.favicon` | `"plutonium.ico"` | Favicon asset. |
 | `assets.stylesheet` | `"plutonium.css"` | Stylesheet entry. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,6 +9,7 @@ Plutonium.configure do |config|
 
   # config.shell = :modern
   # config.navii_host_url = "https://api.navii.dev"
+  # config.auto_eager_load_index = true
 
   config.assets.logo       = "plutonium.png"
   config.assets.favicon    = "plutonium.ico"
@@ -37,6 +38,7 @@ Loads the baseline defaults for a given framework version. Call this first; late
 | `enable_hotreload` | `true` in `development` env | Hot-reload Plutonium components on change. |
 | `shell` | `:modern` | Chrome style: `:modern` (topbar + icon rail), `:plain` (topbar, no icon rail), or `:classic` (legacy header + sidebar, only for upgrades). See [Layouts](./ui/layouts). |
 | `navii_host_url` | `"https://api.navii.dev"` | Host of the [Navii](https://navii.dev) avatar service used by [`Avatar`](./ui/components#avatar). The component appends `/avatar/:seed`. Repoint to self-host or proxy. |
+| `auto_eager_load_index` | `true` | Index pages preload the associations and attachments their columns render. Set `false` to disable globally, or override `auto_eager_load_index?` in a controller. See [Performance](/guides/performance). |
 | `assets.logo` | `"plutonium.png"` | Brand logo asset. See [Assets](./ui/assets). |
 | `assets.favicon` | `"plutonium.ico"` | Favicon asset. |
 | `assets.stylesheet` | `"plutonium.css"` | Stylesheet entry. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,7 +9,7 @@ Plutonium.configure do |config|
 
   # config.shell = :modern
   # config.navii_host_url = "https://api.navii.dev"
-  # config.auto_eager_load_index = true
+  # config.auto_eager_load_collections = true
 
   config.assets.logo       = "plutonium.png"
   config.assets.favicon    = "plutonium.ico"
@@ -38,7 +38,7 @@ Loads the baseline defaults for a given framework version. Call this first; late
 | `enable_hotreload` | `true` in `development` env | Hot-reload Plutonium components on change. |
 | `shell` | `:modern` | Chrome style: `:modern` (topbar + icon rail), `:plain` (topbar, no icon rail), or `:classic` (legacy header + sidebar, only for upgrades). See [Layouts](./ui/layouts). |
 | `navii_host_url` | `"https://api.navii.dev"` | Host of the [Navii](https://navii.dev) avatar service used by [`Avatar`](./ui/components#avatar). The component appends `/avatar/:seed`. Repoint to self-host or proxy. |
-| `auto_eager_load_index` | `true` | Index pages, kanban boards and CSV exports preload the associations and attachments they render. Set `false` to disable globally, or override `auto_eager_load_index?` in a controller. See [Performance](/guides/performance). |
+| `auto_eager_load_collections` | `true` | Index pages, kanban boards and CSV exports preload the associations and attachments they render. Set `false` to disable globally, or override `auto_eager_load_collections?` in a controller. See [Performance](/guides/performance). |
 | `assets.logo` | `"plutonium.png"` | Brand logo asset. See [Assets](./ui/assets). |
 | `assets.favicon` | `"plutonium.ico"` | Favicon asset. |
 | `assets.stylesheet` | `"plutonium.css"` | Stylesheet entry. |

--- a/lib/plutonium/configuration.rb
+++ b/lib/plutonium/configuration.rb
@@ -47,6 +47,16 @@ module Plutonium
     #   change the default, or `false` (or `""`) for no symbol application-wide.
     attr_accessor :default_currency_unit
 
+    # @return [Boolean] whether index pages eager-load the associations and
+    #   attachments they are about to render. On by default.
+    #
+    #   The rendered column set is declared, not discovered — it is resolved from
+    #   the policy before the collection loads — so the framework already knows
+    #   which associations the page will touch and can preload exactly those.
+    #   Turn it off globally here, or per controller via
+    #   `auto_eager_load_index?`.
+    attr_accessor :auto_eager_load_index
+
     # @return [String, nil] the default country (ISO2 code, e.g. "gh") for phone
     #   (`as: :phone`) inputs that don't set their own `initial_country:`. `nil`
     #   (default) leaves it to the intl-tel-input library (no country preselected).
@@ -88,6 +98,7 @@ module Plutonium
       @enable_hotreload = Rails.env.development?
       @shell = :modern
       @navii_host_url = "https://api.navii.dev"
+      @auto_eager_load_index = true
     end
 
     # Load default configuration for a specific version

--- a/lib/plutonium/configuration.rb
+++ b/lib/plutonium/configuration.rb
@@ -47,15 +47,15 @@ module Plutonium
     #   change the default, or `false` (or `""`) for no symbol application-wide.
     attr_accessor :default_currency_unit
 
-    # @return [Boolean] whether index pages eager-load the associations and
-    #   attachments they are about to render. On by default.
+    # @return [Boolean] whether a rendered collection — an index page, a kanban
+    #   board, a CSV export — eager-loads the associations and attachments it is
+    #   about to show. On by default.
     #
-    #   The rendered column set is declared, not discovered — it is resolved from
-    #   the policy before the collection loads — so the framework already knows
-    #   which associations the page will touch and can preload exactly those.
-    #   Turn it off globally here, or per controller via
-    #   `auto_eager_load_index?`.
-    attr_accessor :auto_eager_load_index
+    #   The rendered field set is declared, not discovered: it is resolved from
+    #   the policy before the collection loads, so the framework already knows
+    #   which associations will be touched and can preload exactly those. Turn it
+    #   off globally here, or per controller via `auto_eager_load_collections?`.
+    attr_accessor :auto_eager_load_collections
 
     # @return [String, nil] the default country (ISO2 code, e.g. "gh") for phone
     #   (`as: :phone`) inputs that don't set their own `initial_country:`. `nil`
@@ -98,7 +98,7 @@ module Plutonium
       @enable_hotreload = Rails.env.development?
       @shell = :modern
       @navii_host_url = "https://api.navii.dev"
-      @auto_eager_load_index = true
+      @auto_eager_load_collections = true
     end
 
     # Load default configuration for a specific version

--- a/lib/plutonium/resource/controller.rb
+++ b/lib/plutonium/resource/controller.rb
@@ -12,6 +12,7 @@ module Plutonium
       include Plutonium::Resource::Controllers::Defineable
       include Plutonium::Resource::Controllers::Authorizable
       include Plutonium::Resource::Controllers::Presentable
+      include Plutonium::Resource::Controllers::EagerLoading
       include Plutonium::Resource::Controllers::Queryable
       include Plutonium::Resource::Controllers::CrudActions
       include Plutonium::Resource::Controllers::KanbanActions

--- a/lib/plutonium/resource/controllers/crud_actions/index_action.rb
+++ b/lib/plutonium/resource/controllers/crud_actions/index_action.rb
@@ -8,7 +8,16 @@ module Plutonium
           private
 
           def setup_index_action!
-            @pagy, @resource_records = pagy(:offset, filtered_resource_collection)
+            # Applied HERE, not inside filtered_resource_collection: what to
+            # preload depends on what is about to be RENDERED, and
+            # filtered_resource_collection is shared with the CSV export, which
+            # renders a different column set (`permitted_attributes_for_export`).
+            # Reading the index's fields in there resolved the wrong policy
+            # method for that action and raised. Keeping the hook to filtering and
+            # eager-loading at the point of use also leaves an app's own
+            # `filtered_resource_collection` override unaffected.
+            collection = auto_eager_load(filtered_resource_collection, presentable_attributes)
+            @pagy, @resource_records = pagy(:offset, collection)
           end
 
           def filtered_resource_collection
@@ -18,6 +27,67 @@ module Plutonium
 
             base_query = current_authorized_scope
             current_query_object.apply(base_query, query_params, context: self)
+          end
+
+          # Whether this controller preloads what its index is about to render.
+          # Override to opt a single resource out (or in, against a global off).
+          # @return [Boolean]
+          def auto_eager_load_index?
+            Plutonium.configuration.auto_eager_load_index
+          end
+
+          # Preload the associations and attachments the index will render.
+          #
+          # Plutonium can do this unprompted where a general-purpose Rails app
+          # cannot: the rendered column set is DECLARED — the policy's permitted
+          # attributes, less parent/entity fields — rather than discovered by
+          # running a template, and resolving it never touches the collection. So
+          # by the time this runs the exact set of associations the page will read
+          # is already known. There is no `includes` list to write, and none to
+          # keep in step with the definition as columns come and go.
+          #
+          # `belongs_to` and `has_one` only. `has_many` is deliberately excluded:
+          # preloading one to render a count loads every child row, which loses to
+          # a counter cache, and the row count is unbounded in a way a single
+          # parent is not.
+          # @param fields [Array<Symbol>] the field set about to be rendered.
+          #   Passed in rather than read here, so the same mechanism can serve any
+          #   action that renders a collection (the CSV export is the obvious next
+          #   one — it streams every row, so its N+1 is the worst of the lot).
+          def auto_eager_load(collection, fields)
+            return collection unless auto_eager_load_index?
+
+            associations = fields & eager_loadable_associations
+            collection = collection.includes(*associations) if associations.any?
+
+            # Attachments are not associations under their declared name: for BOTH
+            # backends `reflect_on_association(:file)` is nil, and the reflections
+            # that exist are `file_attachment`/`file_blob`. `with_attached_*` is
+            # the supported preload and ActiveStorage and active_shrine both expose
+            # it, so one path serves both.
+            (fields & eager_loadable_attachments).each do |name|
+              collection = collection.public_send(:"with_attached_#{name}")
+            end
+
+            collection
+          end
+
+          # Both memoised on the model (outside dev) by Resource::Record::FieldNames.
+          # Its `has_one` list already strips the `_attachment`/`_blob` reflections
+          # backing an attachment, so those cannot be loaded twice by the two
+          # branches above. Its attachment lists go through
+          # `reflect_on_all_attachments`, which — unlike `attachment_reflections`,
+          # empty under active_shrine — reports both backends.
+          def eager_loadable_associations
+            @eager_loadable_associations ||=
+              resource_class.belongs_to_association_field_names +
+              resource_class.has_one_association_field_names
+          end
+
+          def eager_loadable_attachments
+            @eager_loadable_attachments ||=
+              resource_class.has_one_attached_field_names +
+              resource_class.has_many_attached_field_names
           end
         end
       end

--- a/lib/plutonium/resource/controllers/crud_actions/index_action.rb
+++ b/lib/plutonium/resource/controllers/crud_actions/index_action.rb
@@ -28,67 +28,6 @@ module Plutonium
             base_query = current_authorized_scope
             current_query_object.apply(base_query, query_params, context: self)
           end
-
-          # Whether this controller preloads what its index is about to render.
-          # Override to opt a single resource out (or in, against a global off).
-          # @return [Boolean]
-          def auto_eager_load_index?
-            Plutonium.configuration.auto_eager_load_index
-          end
-
-          # Preload the associations and attachments the index will render.
-          #
-          # Plutonium can do this unprompted where a general-purpose Rails app
-          # cannot: the rendered column set is DECLARED — the policy's permitted
-          # attributes, less parent/entity fields — rather than discovered by
-          # running a template, and resolving it never touches the collection. So
-          # by the time this runs the exact set of associations the page will read
-          # is already known. There is no `includes` list to write, and none to
-          # keep in step with the definition as columns come and go.
-          #
-          # `belongs_to` and `has_one` only. `has_many` is deliberately excluded:
-          # preloading one to render a count loads every child row, which loses to
-          # a counter cache, and the row count is unbounded in a way a single
-          # parent is not.
-          # @param fields [Array<Symbol>] the field set about to be rendered.
-          #   Passed in rather than read here, so the same mechanism can serve any
-          #   action that renders a collection (the CSV export is the obvious next
-          #   one — it streams every row, so its N+1 is the worst of the lot).
-          def auto_eager_load(collection, fields)
-            return collection unless auto_eager_load_index?
-
-            associations = fields & eager_loadable_associations
-            collection = collection.includes(*associations) if associations.any?
-
-            # Attachments are not associations under their declared name: for BOTH
-            # backends `reflect_on_association(:file)` is nil, and the reflections
-            # that exist are `file_attachment`/`file_blob`. `with_attached_*` is
-            # the supported preload and ActiveStorage and active_shrine both expose
-            # it, so one path serves both.
-            (fields & eager_loadable_attachments).each do |name|
-              collection = collection.public_send(:"with_attached_#{name}")
-            end
-
-            collection
-          end
-
-          # Both memoised on the model (outside dev) by Resource::Record::FieldNames.
-          # Its `has_one` list already strips the `_attachment`/`_blob` reflections
-          # backing an attachment, so those cannot be loaded twice by the two
-          # branches above. Its attachment lists go through
-          # `reflect_on_all_attachments`, which — unlike `attachment_reflections`,
-          # empty under active_shrine — reports both backends.
-          def eager_loadable_associations
-            @eager_loadable_associations ||=
-              resource_class.belongs_to_association_field_names +
-              resource_class.has_one_association_field_names
-          end
-
-          def eager_loadable_attachments
-            @eager_loadable_attachments ||=
-              resource_class.has_one_attached_field_names +
-              resource_class.has_many_attached_field_names
-          end
         end
       end
     end

--- a/lib/plutonium/resource/controllers/eager_loading.rb
+++ b/lib/plutonium/resource/controllers/eager_loading.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Resource
+    module Controllers
+      # Preloads the associations and attachments a collection is about to
+      # render, without being told which.
+      #
+      # Plutonium can do this where a general-purpose Rails app cannot. The
+      # rendered field set is DECLARED — resolved from the policy — rather than
+      # discovered by running a template, and resolving it never touches the
+      # collection. So the exact set of associations a page will read is known
+      # before the query is built. There is no `includes` list to write, and none
+      # to keep in step with the definition as fields come and go.
+      #
+      # Every collection rendering passes its OWN field set, because they differ:
+      # the index renders `presentable_attributes`, the CSV export renders
+      # `permitted_attributes_for_export`, and a kanban card renders its
+      # `card_fields` (falling back to the grid fields). Reading one action's
+      # fields from another's code path resolves the wrong policy method.
+      module EagerLoading
+        extend ActiveSupport::Concern
+
+        private
+
+        # Whether this controller preloads what it is about to render.
+        # Override to opt a single resource out (or in, against a global off).
+        # @return [Boolean]
+        def auto_eager_load_index?
+          Plutonium.configuration.auto_eager_load_index
+        end
+
+        # @param collection [ActiveRecord::Relation]
+        # @param fields [Array<Symbol>] the field set about to be rendered
+        # @return [ActiveRecord::Relation]
+        def auto_eager_load(collection, fields)
+          return collection unless auto_eager_load_index?
+
+          fields = Array(fields).map(&:to_sym)
+
+          associations = fields & eager_loadable_associations
+          collection = collection.includes(*associations) if associations.any?
+
+          # Attachments are not associations under their declared name: for BOTH
+          # backends `reflect_on_association(:file)` is nil, and the reflections
+          # that exist are `file_attachment`/`file_blob`. `with_attached_*` is the
+          # supported preload and ActiveStorage and active_shrine both expose it,
+          # so one path serves both.
+          (fields & eager_loadable_attachments).each do |name|
+            collection = collection.public_send(:"with_attached_#{name}")
+          end
+
+          collection
+        end
+
+        # `belongs_to` and `has_one` only. `has_many` is deliberately excluded:
+        # preloading one to render a count loads every child row, which loses to a
+        # counter cache, and the row count is unbounded in a way a single parent
+        # is not.
+        #
+        # Both lists are memoised on the model (outside dev) by
+        # Resource::Record::FieldNames. Its `has_one` list already strips the
+        # `_attachment`/`_blob` reflections backing an attachment, so those cannot
+        # be loaded twice by the two branches above. Its attachment lists go
+        # through `reflect_on_all_attachments`, which — unlike
+        # `attachment_reflections`, empty under active_shrine — reports both
+        # backends.
+        def eager_loadable_associations
+          @eager_loadable_associations ||=
+            resource_class.belongs_to_association_field_names +
+            resource_class.has_one_association_field_names
+        end
+
+        def eager_loadable_attachments
+          @eager_loadable_attachments ||=
+            resource_class.has_one_attached_field_names +
+            resource_class.has_many_attached_field_names
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/resource/controllers/eager_loading.rb
+++ b/lib/plutonium/resource/controllers/eager_loading.rb
@@ -26,15 +26,15 @@ module Plutonium
         # Whether this controller preloads what it is about to render.
         # Override to opt a single resource out (or in, against a global off).
         # @return [Boolean]
-        def auto_eager_load_index?
-          Plutonium.configuration.auto_eager_load_index
+        def auto_eager_load_collections?
+          Plutonium.configuration.auto_eager_load_collections
         end
 
         # @param collection [ActiveRecord::Relation]
         # @param fields [Array<Symbol>] the field set about to be rendered
         # @return [ActiveRecord::Relation]
         def auto_eager_load(collection, fields)
-          return collection unless auto_eager_load_index?
+          return collection unless auto_eager_load_collections?
 
           fields = Array(fields).map(&:to_sym)
 
@@ -53,13 +53,17 @@ module Plutonium
           collection
         end
 
-        # `belongs_to` and `has_one` only. `has_many` is deliberately excluded:
-        # preloading one to render a count loads every child row, which loses to a
-        # counter cache, and the row count is unbounded in a way a single parent
-        # is not.
+        # Every association kind, `has_many` included.
+        #
+        # `has_many` is preloaded because of what Plutonium actually renders: an
+        # association field renders the associated records' LABELS, not a count.
+        # The rows are read either way, so preloading only decides whether that
+        # costs one query or one per parent. (Excluding it on the usual "a count
+        # beats loading every child row" reasoning is an argument about a
+        # rendering this framework doesn't do.)
         #
         # Both lists are memoised on the model (outside dev) by
-        # Resource::Record::FieldNames. Its `has_one` list already strips the
+        # Resource::Record::FieldNames. Its association lists already strip the
         # `_attachment`/`_blob` reflections backing an attachment, so those cannot
         # be loaded twice by the two branches above. Its attachment lists go
         # through `reflect_on_all_attachments`, which — unlike
@@ -68,7 +72,8 @@ module Plutonium
         def eager_loadable_associations
           @eager_loadable_associations ||=
             resource_class.belongs_to_association_field_names +
-            resource_class.has_one_association_field_names
+            resource_class.has_one_association_field_names +
+            resource_class.has_many_association_field_names
         end
 
         def eager_loadable_attachments

--- a/lib/plutonium/resource/controllers/export_csv.rb
+++ b/lib/plutonium/resource/controllers/export_csv.rb
@@ -34,6 +34,9 @@ module Plutonium
       module ExportCsv
         extend ActiveSupport::Concern
 
+        # Collections rendered here preload what they are about to show.
+        include Plutonium::Resource::Controllers::EagerLoading
+
         # Placeholder written when a column is neither an `export` block nor a
         # real attribute on the record, so the export degrades to a usable file
         # instead of a mid-stream NoMethodError (which would truncate the
@@ -84,7 +87,13 @@ module Plutonium
         #   object entirely (no scope/filter/search/default-scope).
         # Both still respect tenant/parent scoping (current_authorized_scope).
         def export_csv_collection
-          export_all_requested? ? current_authorized_scope : filtered_resource_collection
+          scope = export_all_requested? ? current_authorized_scope : filtered_resource_collection
+          # Preloaded against the EXPORT's own column set, which is
+          # `permitted_attributes_for_export` and need not match the index's.
+          # This is the worst N+1 of the three collection renderings: an export
+          # streams every matching row, not a page of them, so a per-row
+          # association read is unbounded.
+          auto_eager_load(scope, exportable_attributes)
         end
 
         def export_all_requested?

--- a/lib/plutonium/resource/controllers/kanban_actions.rb
+++ b/lib/plutonium/resource/controllers/kanban_actions.rb
@@ -32,6 +32,9 @@ module Plutonium
       module KanbanActions
         extend ActiveSupport::Concern
 
+        # Collections rendered here preload what they are about to show.
+        include Plutonium::Resource::Controllers::EagerLoading
+
         # Tags board-bound redirects with kanban_reload=1 so the permanent board
         # refreshes its cached column frames on arrival (see #kanban_reload_url).
         # Wraps ALL three redirect helpers — create/update (after_submit), destroy
@@ -519,8 +522,24 @@ module Plutonium
               .extract_input(params, view_context:)[:q]
 
             base_query = current_authorized_scope
-            current_query_object.apply(base_query, query_params, context: self)
+            collection = current_query_object.apply(base_query, query_params, context: self)
+            # Preloaded here rather than at each `.to_a`, because every card query
+            # on the board derives from this relation — the column body, the
+            # lazy-loaded frames, the post-move re-render. The sites that `pluck`
+            # or `count` off it instantiate no records, so the preload does not
+            # run for them.
+            auto_eager_load(collection, kanban_card_field_names)
           end
+        end
+
+        # The fields a card actually renders. A board's `card_fields` is a slot
+        # layout — each slot holds one field name, several, or `false` to hide the
+        # slot — so it is flattened to names. A board that declares no layout falls
+        # back to the read attribute set, the same one the column component is
+        # handed as `resource_fields`.
+        def kanban_card_field_names
+          slots = current_kanban_board.card_fields
+          slots ? slots.values.flatten.grep(Symbol) : permitted_attributes_for("index")
         end
 
         # Intercepts the index action when view=kanban + column= is present.

--- a/test/integration/admin_portal/auto_eager_load_collections_test.rb
+++ b/test/integration/admin_portal/auto_eager_load_collections_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 # without being told which. It can, because the rendered column set is declared
 # (the policy's permitted attributes) rather than discovered by running a
 # template — so it is known before the collection loads.
-class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
+class AdminPortal::AutoEagerLoadCollectionsTest < ActionDispatch::IntegrationTest
   include IntegrationTestHelper
 
   setup { login_as_admin(create_admin!) }
@@ -52,14 +52,14 @@ class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
   end
 
   test "without preloading, queries grow one per added row" do
-    Plutonium.configuration.auto_eager_load_index = false
+    Plutonium.configuration.auto_eager_load_collections = false
 
     # At least one query per added row — the exact multiple is however many
     # association columns the page renders, which is not the point.
     assert_operator growth_from_3_to_18, :>=, 15,
       "adding 15 rows should add at least 15 queries when preloading is off"
   ensure
-    Plutonium.configuration.auto_eager_load_index = true
+    Plutonium.configuration.auto_eager_load_collections = true
   end
 
   test "opting out per controller restores the per-row queries" do
@@ -67,26 +67,26 @@ class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
     on = count_sql { get "/admin/blogging/posts" }
 
     AdminPortal::Blogging::PostsController.class_eval do
-      private def auto_eager_load_index? = false
+      private def auto_eager_load_collections? = false
     end
     off = count_sql { get "/admin/blogging/posts" }
 
     assert_operator off, :>, on,
       "with the override off, the N+1 should come back (#{off} vs #{on})"
   ensure
-    AdminPortal::Blogging::PostsController.send(:remove_method, :auto_eager_load_index?)
+    AdminPortal::Blogging::PostsController.send(:remove_method, :auto_eager_load_collections?)
   end
 
   test "the global config switches it off" do
     seed_posts(18)
     on = count_sql { get "/admin/blogging/posts" }
 
-    Plutonium.configuration.auto_eager_load_index = false
+    Plutonium.configuration.auto_eager_load_collections = false
     off = count_sql { get "/admin/blogging/posts" }
 
     assert_operator off, :>, on, "the global config should disable preloading"
   ensure
-    Plutonium.configuration.auto_eager_load_index = true
+    Plutonium.configuration.auto_eager_load_collections = true
   end
 
   # Attachments reflect under neither their declared name nor
@@ -104,13 +104,13 @@ class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
     with_preload = count_sql { get "/admin/shrine_docs" }
     assert_response :success
 
-    Plutonium.configuration.auto_eager_load_index = false
+    Plutonium.configuration.auto_eager_load_collections = false
     without = count_sql { get "/admin/shrine_docs" }
 
     assert_operator with_preload, :<, without,
       "with_attached_* must be applied for a Shrine-backed attachment (#{with_preload} vs #{without})"
   ensure
-    Plutonium.configuration.auto_eager_load_index = true
+    Plutonium.configuration.auto_eager_load_collections = true
   end
 
   # The CSV export streams EVERY matching row, not a page, so its N+1 is
@@ -123,14 +123,14 @@ class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
     on = count_sql { get "/admin/blogging/posts/export_csv" }
     assert_response :success
 
-    Plutonium.configuration.auto_eager_load_index = false
+    Plutonium.configuration.auto_eager_load_collections = false
     off = count_sql { get "/admin/blogging/posts/export_csv" }
     assert_response :success
 
     assert_operator on, :<, off,
       "export should preload its association columns (#{on} vs #{off})"
   ensure
-    Plutonium.configuration.auto_eager_load_index = true
+    Plutonium.configuration.auto_eager_load_collections = true
   end
 
   # Kanban builds its own relation and never runs setup_index_action!, so it
@@ -153,13 +153,43 @@ class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
     on = count_sql { get column_url }
     assert_response :success
 
-    Plutonium.configuration.auto_eager_load_index = false
+    Plutonium.configuration.auto_eager_load_collections = false
     off = count_sql { get column_url }
     assert_response :success
 
     assert_operator on, :<, off,
       "kanban cards should preload their association fields (#{on} vs #{off})"
   ensure
-    Plutonium.configuration.auto_eager_load_index = true
+    Plutonium.configuration.auto_eager_load_collections = true
+  end
+
+  # A has_many column renders the associated records' labels, not a count, so
+  # the rows are read either way — preloading only decides whether that costs
+  # one query or one per parent.
+  test "a rendered has_many is preloaded like any other association" do
+    org = create_organization!
+    Blogging::Post.delete_all
+    12.times do
+      post = create_post!(user: create_user!, organization: org)
+      2.times { post.tags << Blogging::Tag.create!(name: "t#{SecureRandom.hex(3)}") }
+    end
+
+    Blogging::PostPolicy.class_eval do
+      def permitted_attributes_for_index = %i[title user tags]
+    end
+
+    get "/admin/blogging/posts" # warm
+    on = count_sql { get "/admin/blogging/posts" }
+    assert_response :success
+
+    Plutonium.configuration.auto_eager_load_collections = false
+    off = count_sql { get "/admin/blogging/posts" }
+    assert_response :success
+
+    assert_operator on, :<, off,
+      "a rendered has_many should be preloaded (#{on} vs #{off})"
+  ensure
+    Plutonium.configuration.auto_eager_load_collections = true
+    Blogging::PostPolicy.send(:remove_method, :permitted_attributes_for_index)
   end
 end

--- a/test/integration/admin_portal/auto_eager_load_index_test.rb
+++ b/test/integration/admin_portal/auto_eager_load_index_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The index preloads the associations and attachments its columns will render,
+# without being told which. It can, because the rendered column set is declared
+# (the policy's permitted attributes) rather than discovered by running a
+# template — so it is known before the collection loads.
+class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelper
+
+  setup { login_as_admin(create_admin!) }
+
+  def count_sql
+    n = 0
+    sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      n += 1 unless /SCHEMA|TRANSACTION/.match?(payload[:name].to_s)
+    end
+    yield
+    ActiveSupport::Notifications.unsubscribe(sub)
+    n
+  end
+
+  def seed_posts(n)
+    org = create_organization!
+    Blogging::Post.delete_all
+    n.times { create_post!(user: create_user!, organization: org) }
+    org
+  end
+
+  # The property that matters isn't an absolute query count, it's that the count
+  # stops tracking the row count. Measured as growth from 3 rows to 18, with
+  # preloading on and off, so the comparison is against this app's own baseline
+  # rather than a magic number.
+  def growth_from_3_to_18
+    seed_posts(3)
+    get "/admin/blogging/posts"          # warm: first request pays one-time costs
+    few = count_sql { get "/admin/blogging/posts" }
+    assert_response :success
+
+    seed_posts(18)
+    get "/admin/blogging/posts"
+    many = count_sql { get "/admin/blogging/posts" }
+    assert_response :success
+
+    many - few
+  end
+
+  test "queries do not grow with rows" do
+    assert_equal 0, growth_from_3_to_18,
+      "index queries must not scale with rows"
+  end
+
+  test "without preloading, queries grow one per added row" do
+    Plutonium.configuration.auto_eager_load_index = false
+
+    # At least one query per added row — the exact multiple is however many
+    # association columns the page renders, which is not the point.
+    assert_operator growth_from_3_to_18, :>=, 15,
+      "adding 15 rows should add at least 15 queries when preloading is off"
+  ensure
+    Plutonium.configuration.auto_eager_load_index = true
+  end
+
+  test "opting out per controller restores the per-row queries" do
+    seed_posts(18)
+    on = count_sql { get "/admin/blogging/posts" }
+
+    AdminPortal::Blogging::PostsController.class_eval do
+      private def auto_eager_load_index? = false
+    end
+    off = count_sql { get "/admin/blogging/posts" }
+
+    assert_operator off, :>, on,
+      "with the override off, the N+1 should come back (#{off} vs #{on})"
+  ensure
+    AdminPortal::Blogging::PostsController.send(:remove_method, :auto_eager_load_index?)
+  end
+
+  test "the global config switches it off" do
+    seed_posts(18)
+    on = count_sql { get "/admin/blogging/posts" }
+
+    Plutonium.configuration.auto_eager_load_index = false
+    off = count_sql { get "/admin/blogging/posts" }
+
+    assert_operator off, :>, on, "the global config should disable preloading"
+  ensure
+    Plutonium.configuration.auto_eager_load_index = true
+  end
+
+  # Attachments reflect under neither their declared name nor
+  # `attachment_reflections` (empty for active_shrine), so this is the case a
+  # naive `reflect_on_association` sweep silently skips.
+  test "an active_shrine attachment column is preloaded too" do
+    ShrineDoc.delete_all
+    6.times do |i|
+      io = StringIO.new("hello")
+      io.singleton_class.define_method(:original_filename) { "f#{i}.txt" }
+      io.singleton_class.define_method(:content_type) { "text/plain" }
+      ShrineDoc.create!(title: "doc #{i}", file: io)
+    end
+
+    with_preload = count_sql { get "/admin/shrine_docs" }
+    assert_response :success
+
+    Plutonium.configuration.auto_eager_load_index = false
+    without = count_sql { get "/admin/shrine_docs" }
+
+    assert_operator with_preload, :<, without,
+      "with_attached_* must be applied for a Shrine-backed attachment (#{with_preload} vs #{without})"
+  ensure
+    Plutonium.configuration.auto_eager_load_index = true
+  end
+end

--- a/test/integration/admin_portal/auto_eager_load_index_test.rb
+++ b/test/integration/admin_portal/auto_eager_load_index_test.rb
@@ -112,4 +112,54 @@ class AdminPortal::AutoEagerLoadIndexTest < ActionDispatch::IntegrationTest
   ensure
     Plutonium.configuration.auto_eager_load_index = true
   end
+
+  # The CSV export streams EVERY matching row, not a page, so its N+1 is
+  # unbounded. It also renders its own column set
+  # (`permitted_attributes_for_export`), which is why it passes its own fields
+  # rather than reusing the index's.
+  test "the csv export preloads its own column set" do
+    seed_posts(18)
+
+    on = count_sql { get "/admin/blogging/posts/export_csv" }
+    assert_response :success
+
+    Plutonium.configuration.auto_eager_load_index = false
+    off = count_sql { get "/admin/blogging/posts/export_csv" }
+    assert_response :success
+
+    assert_operator on, :<, off,
+      "export should preload its association columns (#{on} vs #{off})"
+  ensure
+    Plutonium.configuration.auto_eager_load_index = true
+  end
+
+  # Kanban builds its own relation and never runs setup_index_action!, so it
+  # needs wiring separately. KitchenSink's board declares
+  # `card_fields ... meta: [..., :user]`, so cards render a belongs_to.
+  #
+  # Measured at the COLUMN endpoint, not `?view=kanban`: the board is lazy, so
+  # the bare view renders an empty shell and materialises no cards at all. Each
+  # column body arrives in its own turbo-frame request, and that is where the
+  # per-card association reads happen.
+  test "a kanban board preloads the associations its cards render" do
+    org = create_organization!
+    KitchenSink.delete_all
+    12.times do |i|
+      KitchenSink.create!(name: "ks #{i}", organization: org, user: create_user!, status: :active)
+    end
+
+    column_url = "/admin/kitchen_sinks?view=kanban&column=active"
+    get column_url # warm the session so auth lookups don't skew the count
+    on = count_sql { get column_url }
+    assert_response :success
+
+    Plutonium.configuration.auto_eager_load_index = false
+    off = count_sql { get column_url }
+    assert_response :success
+
+    assert_operator on, :<, off,
+      "kanban cards should preload their association fields (#{on} vs #{off})"
+  ensure
+    Plutonium.configuration.auto_eager_load_index = true
+  end
 end

--- a/test/plutonium/resource/controllers/export_csv_test.rb
+++ b/test/plutonium/resource/controllers/export_csv_test.rb
@@ -60,6 +60,18 @@ class Plutonium::Resource::Controllers::ExportCsvTest < Minitest::Test
     Class.new do
       def self.primary_key = "id"
       def self.model_name = OpenStruct.new(human: "Widget")
+
+      # The export preloads the associations its columns render, so it asks the
+      # resource class what those are. A real resource gets these from
+      # Plutonium::Resource::Record::FieldNames; this double has none, which is
+      # what keeps `includes` off the FakeRelation below.
+      def self.belongs_to_association_field_names = []
+
+      def self.has_one_association_field_names = []
+
+      def self.has_one_attached_field_names = []
+
+      def self.has_many_attached_field_names = []
     end
   end
 

--- a/test/plutonium/resource/controllers/export_csv_test.rb
+++ b/test/plutonium/resource/controllers/export_csv_test.rb
@@ -69,6 +69,8 @@ class Plutonium::Resource::Controllers::ExportCsvTest < Minitest::Test
 
       def self.has_one_association_field_names = []
 
+      def self.has_many_association_field_names = []
+
       def self.has_one_attached_field_names = []
 
       def self.has_many_attached_field_names = []


### PR DESCRIPTION
## What

Index pages, kanban boards and CSV exports now eager-load the associations and attachments they are about to render. On by default; no per-app configuration.

```ruby
config.auto_eager_load_collections = false   # global
def auto_eager_load_collections? = false     # per controller
```

Plus a `guides/performance` page covering the N+1 story, and the cases the framework still can't resolve for you.

## Why it can be automatic here

A general-purpose Rails app can't do this: the view is arbitrary code, so nothing knows which associations a template will touch until it runs. In Plutonium the rendered field set is **declared** — resolved from the policy — and resolving it never touches the collection. So the exact set of associations a page will read is known before the query is built. There is no `includes` list to write, and none to keep in step with the definition as fields come and go.

Measured on the dummy app: index queries go from `7 + rows` to flat; the kanban column endpoint from 13 queries to 4.

## Each rendering passes its own field set

They genuinely differ, and conflating them resolves the wrong policy method — the export tests caught exactly that mid-development:

| Rendering | Fields |
|---|---|
| index | `presentable_attributes` |
| CSV export | `permitted_attributes_for_export` |
| kanban card | the board's `card_fields` slot layout, flattened |

The export is the worst N+1 of the three: it streams every matching row rather than a page, so a per-row association read is unbounded. Kanban preloads at `kanban_base_relation`, so column bodies, lazy frames and post-move re-renders all inherit it; the sites that `pluck` or `count` off it instantiate no records, so a lazy board's shell issues the same single `COUNT` it always did.

## Attachments were the trap

Both backends were verified, and the obvious implementation is silently wrong for one of them:

| | ActiveStorage | active_shrine |
|---|---|---|
| `reflect_on_association(:file)` | `nil` | `nil` |
| `attachment_reflections` | `{"file"=>…}` | **`{}`** |
| `reflect_on_all_attachments` | `[:file]` | `[:file]` |
| `with_attached_file` | ✓ | ✓ |
| N+1 over 10 rows | 21 → 5 | 11 → 2 |

`attachment_reflections` is the API you'd reach for and it is **empty under active_shrine** — anything built on it passes its tests with ActiveStorage and does nothing for Shrine users. This goes through `reflect_on_all_attachments` (via the existing `Resource::Record::FieldNames` helpers, which already memoise and already strip the `_attachment`/`_blob` reflections), so one path serves both.

## Scope

Every association kind — `belongs_to`, `has_one`, `has_many` — plus attachments.

`has_many` is included because of what this framework renders: an association field renders the associated records' **labels**, not a count, so the rows are read either way and preloading only decides whether that costs one query or one per parent. Measured with a rendered `has_many` on 12 rows: **20 queries excluded, 10 included**.

## Upgrade note

Behaviour change, not an API change — no app code needs to move. The one thing to watch is a resource whose filters or sorts already `joins` a table that is now also `includes`d, which can flip Rails into `eager_load` and change the query shape. `auto_eager_load_collections?` opts a single controller out.

## Verification

rails-7 / rails-8.0 / rails-8.1: 2747 tests, 0 failures, 0 errors. System suite: 14 tests, 110 assertions, 0 failures. `standardrb` clean. `yarn docs:build` clean.

## Docs

`guides/performance` documents the automatic behaviour first, then what still needs declaring by hand (a custom column block, a show page), then goldiloader for that remainder. The `plutonium-behavior` skill tells the agent **not** to add eager loading unprompted — an `includes` list written on its initiative is a guess that goes stale — and to suggest goldiloader first when a user actually reports a slow index.

Drive-by: `guides/troubleshooting` was on the guides overview but missing from the sidebar, so it was unreachable by navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDJ4A3cWgH5H3EvYKStqPv

