### PR TITLE
fix(ui): call to_s on attachment filename before Phlex title attribute

### DIFF
--- a/lib/plutonium/ui/table/components/attachment.rb
+++ b/lib/plutonium/ui/table/components/attachment.rb
@@ -27,7 +27,7 @@ module Plutonium
                 attachment_preview_thumbnail_url_value: attachment_thumbnail_url(attachment),
                 attachment_preview_target: "thumbnail"
               },
-              title: attachment.filename
+              title: attachment.filename.to_s
             ) do
               a(
                 href: attachment.url,

--- a/test/plutonium/ui/table/components/attachment_test.rb
+++ b/test/plutonium/ui/table/components/attachment_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression: ActiveStorage::Blob#filename returns an ActiveStorage::Filename,
+# NOT a String. Phlex 2.4 validates attribute values and raises
+# Phlex::ArgumentError when a `title:` is handed a non-String. Every filename
+# that flows into an HTML attribute (or `plain`) must therefore be coerced with
+# `.to_s`. Same bug as the Display component (see
+# test/plutonium/ui/display/components/attachment_test.rb), but on the table
+# column renderer, which was missed when that one was fixed.
+class Plutonium::UI::Table::Components::AttachmentTest < ActiveSupport::TestCase
+  Component = Plutonium::UI::Table::Components::Attachment
+
+  # A faithful stand-in for an attached blob: `filename` returns the real
+  # ActiveStorage::Filename object, exactly as the index table sees it.
+  def fake_attachment
+    att = Object.new
+    att.define_singleton_method(:url) { "/blob/example.jpg" }
+    att.define_singleton_method(:filename) { ActiveStorage::Filename.new("example.jpg") }
+    att.define_singleton_method(:content_type) { "image/jpeg" }
+    att.define_singleton_method(:representable?) { false }
+    att.define_singleton_method(:try) { |_m| nil }
+    att
+  end
+
+  # Renders render_value with the Phlex DSL stubbed, capturing every `title:`
+  # attribute that reaches an element.
+  def render_value(attachment)
+    component = Component.allocate
+    titles = []
+
+    component.define_singleton_method(:attributes) { {} }
+
+    %i[div a span img].each do |tag|
+      component.define_singleton_method(tag) do |*_args, **attrs, &block|
+        titles << attrs[:title] if attrs.key?(:title)
+        block&.call
+        nil
+      end
+    end
+    component.define_singleton_method(:plain) { |_text| nil }
+    component.define_singleton_method(:phlexi_render) { |_value, &block| block&.call }
+
+    component.send(:render_value, attachment)
+    titles
+  end
+
+  test "title attribute is a plain String, not an ActiveStorage::Filename" do
+    titles = render_value(fake_attachment)
+
+    refute_empty titles, "expected render_value to set a title attribute"
+    titles.each do |title|
+      assert_instance_of String, title,
+        "title must be a String for Phlex 2.4 attribute validation, got #{title.class}"
+    end
+    assert_includes titles, "example.jpg"
+  end
+end


### PR DESCRIPTION
## Summary

`ActiveStorage::Blob#filename` returns an `ActiveStorage::Filename`, not a `String`. Phlex 2.4 validates HTML attribute values and raises `Phlex::ArgumentError` when a `title:` is handed a non-`String`, so any resource with a `has_one_attached`/`has_many_attached` field crashes the first time it's rendered in an index table:

```
Phlex::ArgumentError: Invalid attribute value for title: #<ActiveStorage::Filename:0x... @filename="example.tei">.
```

`lib/plutonium/ui/display/components/attachment.rb` already coerces this correctly with `attachment.filename.to_s` (both occurrences). `lib/plutonium/ui/table/components/attachment.rb` was missed — this is the index-table column renderer, hit as soon as an attachment field is listed.

- Adds `.to_s` at the one call site in the table component.
- Adds `test/plutonium/ui/table/components/attachment_test.rb`, mirroring the existing `test/plutonium/ui/display/components/attachment_test.rb` regression test for the same class of bug.
