### PR TITLE
fix(policy): relation_scope written as an instance method silently does nothing

### DIFF
--- a/docs/getting-started/tutorial/04-authorization.md
+++ b/docs/getting-started/tutorial/04-authorization.md
@@ -108,10 +108,19 @@ end
 
 Control which records appear in listings:
 
+`relation_scope` is a macro — it takes a block. Writing it as a plain instance
+method (`def relation_scope(relation)`) overrides nothing and your scoping is
+silently ignored, so Plutonium raises if you try.
+
+Always compose with `default_relation_scope(relation)`; skipping it raises too,
+because it is what applies parent and tenant scoping.
+
 ```ruby
 class Blogging::PostPolicy < Blogging::ResourcePolicy
   # Called when listing posts
-  def relation_scope(relation)
+  relation_scope do |relation|
+    relation = default_relation_scope(relation)
+
     if admin?
       relation # Admins see everything
     else
@@ -147,8 +156,8 @@ class AdminPortal::Blogging::PostPolicy < ::Blogging::PostPolicy
     true
   end
 
-  def relation_scope(relation)
-    relation # No scope restrictions for admins
+  relation_scope do |relation|
+    default_relation_scope(relation) # No extra restrictions for admins
   end
 end
 ```

--- a/docs/getting-started/tutorial/06-nested-resources.md
+++ b/docs/getting-started/tutorial/06-nested-resources.md
@@ -101,7 +101,9 @@ class Blogging::CommentPolicy < Blogging::ResourcePolicy
   end
 
   # Scope to comments on published posts (or user's own posts)
-  def relation_scope(relation)
+  relation_scope do |relation|
+    relation = default_relation_scope(relation)
+
     relation.joins(:post).where(
       blogging_posts: {published: true}
     ).or(

--- a/docs/getting-started/tutorial/07-author-portal.md
+++ b/docs/getting-started/tutorial/07-author-portal.md
@@ -84,8 +84,8 @@ Authors should only see and manage their own posts. Create a portal-specific pol
 # packages/author_portal/app/policies/author_portal/blogging/post_policy.rb
 class AuthorPortal::Blogging::PostPolicy < ::Blogging::PostPolicy
   # Authors can only see their own posts
-  def relation_scope(relation)
-    relation.where(user_id: user.id)
+  relation_scope do |relation|
+    default_relation_scope(relation).where(user_id: user.id)
   end
 
   # Authors can always create posts

--- a/lib/plutonium/resource/policy.rb
+++ b/lib/plutonium/resource/policy.rb
@@ -21,6 +21,30 @@ module Plutonium
         default_relation_scope(relation)
       end
 
+      # `relation_scope` is a class-level macro: it registers a scope handler named
+      # `__scoping__active_record_relation__default`, and never defines an instance
+      # method called `relation_scope`. So `def relation_scope(relation)` overrides
+      # nothing — apply_scope keeps dispatching to the inherited handler, the author's
+      # narrowing never runs, and verify_default_relation_scope_applied! is happy
+      # because the base handler did call default_relation_scope. Fail-open and silent,
+      # so catch it the moment the method is defined rather than at request time.
+      def self.method_added(name)
+        super
+
+        return unless name == :relation_scope
+
+        raise <<~MSG
+          #{self} defines `relation_scope` as an instance method, which Plutonium never calls.
+          `relation_scope` is a macro, so this scoping silently does nothing.
+
+          Use the block form instead:
+
+            relation_scope do |relation|
+              default_relation_scope(relation).your_scope
+            end
+        MSG
+      end
+
       # Wraps apply_scope to verify default_relation_scope was called.
       # This prevents accidental multi-tenancy leaks when overriding relation_scope.
       def apply_scope(relation, type:, **options)

--- a/lib/plutonium/testing/resource_policy.rb
+++ b/lib/plutonium/testing/resource_policy.rb
@@ -24,7 +24,11 @@ module Plutonium
             matrix.each do |action, allowed_roles|
               roles.each do |role_sym, account_proc|
                 account = instance_exec(&account_proc)
-                policy = policy_klass.new(record: record, user: account, **policy_context)
+                # The record MUST be positional. ActionPolicy::Policy::Core#initialize is
+                # `def initialize(record = nil, *)`, so a `record:` keyword is swallowed by
+                # the splat and `record` stays nil — every record-dependent predicate would
+                # then be asserted against nil.
+                policy = policy_klass.new(record, user: account, **policy_context)
                 expected = allowed_roles.include?(role_sym)
                 actual = policy.public_send("#{action}?")
                 assert_equal expected, actual,
@@ -38,7 +42,7 @@ module Plutonium
             policy_klass = policy_class_for(record)
             policy_roles.each do |role_sym, account_proc|
               account = instance_exec(&account_proc)
-              policy = policy_klass.new(record: record.class, user: account, **policy_context)
+              policy = policy_klass.new(record.class, user: account, **policy_context)
               scope = policy.apply_scope(record.class.all, type: :active_record_relation)
               assert_kind_of ActiveRecord::Relation, scope, "relation_scope must return AR::Relation for #{role_sym}"
             end

--- a/test/dummy/packages/storefront_portal/app/policies/storefront_portal/blogging/post_policy.rb
+++ b/test/dummy/packages/storefront_portal/app/policies/storefront_portal/blogging/post_policy.rb
@@ -17,7 +17,7 @@ class StorefrontPortal::Blogging::PostPolicy < ::Blogging::PostPolicy
     %i[]
   end
 
-  def relation_scope(relation)
+  relation_scope do |relation|
     default_relation_scope(relation).published
   end
 end

--- a/test/dummy/packages/storefront_portal/app/policies/storefront_portal/catalog/product_policy.rb
+++ b/test/dummy/packages/storefront_portal/app/policies/storefront_portal/catalog/product_policy.rb
@@ -17,7 +17,7 @@ class StorefrontPortal::Catalog::ProductPolicy < ::Catalog::ProductPolicy
     %i[]
   end
 
-  def relation_scope(relation)
+  relation_scope do |relation|
     default_relation_scope(relation).active
   end
 end

--- a/test/integration/storefront_portal/public_access_test.rb
+++ b/test/integration/storefront_portal/public_access_test.rb
@@ -35,6 +35,32 @@ class StorefrontPortal::PublicAccessTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # The storefront policies narrow to published posts / active products. That
+  # narrowing was silently dead while it was written as a `relation_scope`
+  # instance method, and nothing above would have noticed — every case here
+  # creates an already-visible record.
+  test "public: post index excludes drafts" do
+    published = create_post!(status: :published, title: "Published Post")
+    draft = create_post!(status: :draft, title: "Draft Post")
+
+    get "/storefront/blogging/posts"
+
+    assert_response :success
+    assert_match published.title, response.body
+    refute_match draft.title, response.body
+  end
+
+  test "public: product index excludes inactive products" do
+    active = create_product!(status: :active, name: "Active Product")
+    inactive = create_product!(status: :discontinued, name: "Discontinued Product")
+
+    get "/storefront/catalog/products"
+
+    assert_response :success
+    assert_match active.name, response.body
+    refute_match inactive.name, response.body
+  end
+
   test "public: lists categories without auth" do
     create_category!
     get "/storefront/catalog/categories"

--- a/test/plutonium/resource/policy_test.rb
+++ b/test/plutonium/resource/policy_test.rb
@@ -306,6 +306,39 @@ class Plutonium::Resource::PolicyTest < Minitest::Test
     assert_includes scoped.to_a, @other_post
   end
 
+  # relation_scope shape tests
+
+  # Named so the raise has something to identify; reopened inside the test
+  # because the guard fires while the offending `def` is being evaluated.
+  class InstanceMethodScopePolicy < Plutonium::Resource::Policy; end
+
+  def test_raises_when_relation_scope_is_defined_as_an_instance_method
+    error = assert_raises(RuntimeError) do
+      InstanceMethodScopePolicy.class_eval do
+        def relation_scope(relation)
+          default_relation_scope(relation).where(id: 1)
+        end
+      end
+    end
+
+    assert_match(/InstanceMethodScopePolicy/, error.message)
+    assert_match(/relation_scope do \|relation\|/, error.message)
+  end
+
+  def test_no_error_when_relation_scope_uses_the_macro
+    macro_policy_class = Class.new(Plutonium::Resource::Policy) do
+      relation_scope do |relation|
+        default_relation_scope(relation).where(user_id: nil)
+      end
+    end
+
+    policy = macro_policy_class.new(Blogging::Post, user: @user, entity_scope: nil)
+    scoped = policy.apply_scope(Blogging::Post.all, type: :active_record_relation)
+
+    # The macro form actually narrows, unlike the instance-method form it replaces.
+    assert_empty scoped.to_a
+  end
+
   # Typeahead permission tests
 
   def test_typeahead_defaults_to_index

--- a/test/plutonium/testing/resource_policy_test.rb
+++ b/test/plutonium/testing/resource_policy_test.rb
@@ -33,3 +33,38 @@ class Plutonium::Testing::ResourcePolicyTest < ActiveSupport::TestCase
     }
   end
 end
+
+# Regression: the helper used to build policies as `new(record: record, ...)`, and
+# ActionPolicy swallows that keyword into a splat, leaving `record` nil. Every
+# record-dependent predicate was therefore asserted against nil.
+#
+# Blogging::PostPolicy#publish? is `record.draft?` and #archive? is `record.published?`.
+# The matrix below only holds if the record genuinely arrives *and* carries its state;
+# against a nil record the helper raises NoMethodError instead.
+class Plutonium::Testing::ResourcePolicyRecordArgTest < ActiveSupport::TestCase
+  include IntegrationTestHelper
+  include Plutonium::Testing::ResourcePolicy
+
+  resource_tests_for Blogging::Post, portal: :admin
+
+  setup do
+    @admin = create_admin!
+    @org = create_organization!
+    @user = create_user!
+  end
+
+  def policy_roles
+    {admin: -> { @admin }, member: -> { @user }}
+  end
+
+  def policy_record
+    create_post!(user: @user, organization: @org, status: :draft)
+  end
+
+  def policy_matrix
+    {
+      publish: %i[admin member],
+      archive: []
+    }
+  end
+end

--- a/test/tutorial_test.rb
+++ b/test/tutorial_test.rb
@@ -97,8 +97,11 @@ class TutorialTest < Minitest::Test
     draft = Blogging::Post.create!(title: "Draft", body: "Body", status: :draft, user: @user, organization: @org)
     published = Blogging::Post.create!(title: "Published", body: "Body", status: :published, user: @user, organization: @org)
 
-    policy = StorefrontPortal::Blogging::PostPolicy.new(record: Blogging::Post, user: "Guest", entity_scope: nil)
-    scoped = policy.relation_scope(Blogging::Post.all)
+    # Must go through apply_scope: that is what the framework calls, and it
+    # dispatches to the relation_scope macro's handler. Calling a `relation_scope`
+    # instance method instead is what let the missing narrowing hide here.
+    policy = StorefrontPortal::Blogging::PostPolicy.new(Blogging::Post, user: "Guest", entity_scope: nil)
+    scoped = policy.apply_scope(Blogging::Post.all, type: :active_record_relation)
 
     assert_includes scoped, published
     refute_includes scoped, draft


### PR DESCRIPTION
Two independent bugs found while building an unrelated feature. Both are in shipped code and affect host applications.

## 1. `relation_scope` as an instance method silently does nothing

`Plutonium::Resource::Policy` declares the scope with ActionPolicy's **macro**:

```ruby
relation_scope do |relation|
  default_relation_scope(relation)
end
```

`relation_scope` is a class-method alias for `scope_for :active_record_relation`, and `scope_for` only ever calls `define_method(:"__scoping__#{type}__#{name}")`. `apply_scope` dispatches to that generated method.

A subclass that writes `def relation_scope(relation)` as a plain **instance method** therefore overrides nothing. The base macro still runs, `default_relation_scope` is still called, the existing `verify_default_relation_scope_applied!` guard still passes — and the intended narrowing never happens. No error, no warning.

Verified against the dummy app before the fix:

```
apply_scope sql    => SELECT "blogging_posts".* FROM "blogging_posts"   # no .published
apply_scope titles => ["Draft", "Pub"]
policy.relation_scope(...) titles => ["Pub"]                            # only a direct call applies it
```

**Two live instances existed in this repo** — `StorefrontPortal::Blogging::PostPolicy` (`.published`) and `StorefrontPortal::Catalog::ProductPolicy` (`.active`). Neither filter had ever run.

### The tutorial is the source

Four places teach the broken form: `docs/getting-started/tutorial/04-authorization.md` (×2), `06-nested-resources.md`, `07-author-portal.md`. The dummy app is the tutorial's output, which is how both broken policies came to be written. Three of those examples also omit `default_relation_scope`, so they would trip the existing multi-tenancy guard as well.

Any host app that followed the tutorial has silently non-functional scope narrowing. All four are corrected here. (`.claude/skills/` docs were already correct.)

### The fix

`self.method_added` raises when a `Plutonium::Resource::Policy` subclass defines `relation_scope` as an instance method, naming the class and pointing at the macro form. It fires at class-load with the definition site in the backtrace.

`inherited` cannot work — it runs before the class body, so the method does not exist yet. A check at scope-application time would be later, would only fire if that path is exercised, and would cost something on every index request.

The discriminator is unambiguous: the base class defines no instance method named `relation_scope`, so the name can only appear if a human wrote it.

**Known residual gap:** `method_added` does not fire for methods arriving via an included module. Nothing in the repo does this, and a second runtime check in `apply_scope` would be the defensive programming CLAUDE.md warns against.

## 2. The shipped testing helper builds policies with a nil record

`lib/plutonium/testing/resource_policy.rb:27,41` construct policies as `policy_klass.new(record: record, ...)`.

`ActionPolicy::Policy::Core#initialize` is `def initialize(record = nil, *)`. The keyword is swallowed into the splat and `@record` stays nil. ActionPolicy's own source comments the keyword form as a future API (`NEXT_RELEASE: deprecate record arg`).

```
keyword form  Policy.new(record: post, ...).record => nil
positional    Policy.new(post, ...).record        => #<Blogging::Post ...>
```

Consequence: any host app using this helper to assert a **record-dependent** predicate (`def archive? = record.published?`) is asserting against `nil` — raising confusingly, or passing vacuously.

Both call sites now pass the record positionally.

## Tests

2930 → 2936 tests, 0 failures. Each new test was verified red before its fix.

**One existing test was asserting the bug.** `test/tutorial_test.rb:96` called `policy.relation_scope(...)` directly — the dead instance method the framework never invokes — and so "proved" a narrowing that did not exist in production. It now calls `apply_scope`.

**The storefront suite was structurally blind.** Every case created an already-visible record and asserted `:success`; nothing ever asserted that a hidden record is *excluded*. Two exclusion tests added.

## Not fixed here

- `Plutonium::Testing::ResourcePolicy#policy_class_for` derives `"#{record.class.name}Policy"` — the global policy, never the portal-specific one, despite `resource_tests_for` accepting a `portal:`.
- ~12 test sites still construct policies with the `record:` keyword. They pass only because they exercise paths that never read `record`, but they teach the wrong idiom.