### PR TITLE
fix(test): stop Turbo's cross-document node swap failing system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,6 +5,37 @@ require "capybara/rails"
 require "capybara/minitest"
 require "selenium/webdriver"
 
+# Treat chromedriver's cross-document node error as a retryable element error.
+#
+# Turbo Drive renders a visit by parsing the response into a SEPARATE document
+# and then adopting it into the live one (`activateNewBody` calls
+# `document.adoptNode`). A Capybara query that is mid-flight when that lands
+# holds element handles whose ownerDocument just changed, and chromedriver
+# rejects them with:
+#
+#   UnknownError: unhandled inspector error:
+#   {"code":-32000,"message":"Node with given id does not belong to the document"}
+#
+# Capybara already handles "the DOM moved under me" by retrying: `synchronize`
+# re-runs the block for every error in `driver.invalid_element_errors`, which
+# includes StaleElementReferenceError. Plain detach, navigation and whole
+# document replacement all raise THAT error and are absorbed silently.
+# Cross-document adoption is the one variant chromedriver reports as
+# UnknownError instead, so it escapes the retry loop and fails the test — which
+# is why this surfaced in CI as unrelated system tests erroring at random,
+# always shortly after a Turbo navigation.
+#
+# Classifying it restores the behaviour Capybara already intends. Capybara does
+# the same for InvalidSelectorError ("Work around chromedriver
+# go_back/go_forward race condition"). It has to be the error CLASS because
+# `catch_error?` matches with `is_a?`, so a message-scoped matcher is never
+# consulted; a genuine persistent UnknownError therefore still fails the test,
+# just after the query's wait expires rather than immediately.
+module CapybaraRetryCrossDocumentNode
+  def invalid_element_errors = super + [::Selenium::WebDriver::Error::UnknownError]
+end
+Capybara::Selenium::Driver.prepend(CapybaraRetryCrossDocumentNode)
+
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless=new")

--- a/test/system/capybara_retry_classification_test.rb
+++ b/test/system/capybara_retry_classification_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+# Guards the harness patch in application_system_test_case.rb.
+#
+# Turbo Drive adopts each new body into the live document, and a Capybara query
+# mid-flight when that lands gets chromedriver's
+# UnknownError("Node with given id does not belong to the document") instead of
+# the StaleElementReferenceError every other DOM-moved-under-me case raises.
+# Capybara retries the latter and not the former, so the harness classifies it
+# as retryable. If that patch is dropped, unrelated system tests start failing
+# at random after a navigation — a very expensive thing to re-diagnose, hence
+# this test.
+#
+# Deliberately driver-level and browser-free: the real condition is a race, so
+# asserting on it directly would itself be flaky.
+class CapybaraRetryClassificationTest < ActiveSupport::TestCase
+  def driver = Capybara::Selenium::Driver.new(nil, browser: :chrome)
+
+  test "the cross-document node error is classified retryable" do
+    assert_includes driver.invalid_element_errors,
+      ::Selenium::WebDriver::Error::UnknownError,
+      "chromedriver reports Turbo's cross-document adoption as UnknownError; " \
+      "without it in this list Capybara's synchronize loop fails instead of retrying"
+  end
+
+  # The patch must ADD to Capybara's list, never replace it — dropping the
+  # stale-element error would break the ordinary retry path.
+  test "the stock retryable errors are preserved" do
+    errors = driver.invalid_element_errors
+
+    assert_includes errors, ::Selenium::WebDriver::Error::StaleElementReferenceError
+    assert_includes errors, ::Selenium::WebDriver::Error::ElementNotInteractableError
+    assert_includes errors, ::Selenium::WebDriver::Error::ElementClickInterceptedError
+  end
+
+  # Capybara's catch_error? uses `error.is_a?(type)`, so only real classes in
+  # the list are ever consulted. This pins the assumption the patch rests on:
+  # if it ever changed to `===`, a precise message-scoped matcher would be
+  # possible and preferable to whitelisting the whole class.
+  test "catch_error? matches by is_a?, which is why the whole class is listed" do
+    source = Capybara::Node::Base.instance_method(:catch_error?).source_location
+    body = File.read(source.first).lines[(source.last - 1), 6].join
+
+    assert_includes body, "is_a?",
+      "if this became `===`, narrow the patch to the cross-document message"
+  end
+end


### PR DESCRIPTION
## The symptom

Three *unrelated* system tests have been erroring at random in CI, always with the same message, always shortly after a Turbo navigation, always clearing on a re-run:

```
Selenium::WebDriver::Error::UnknownError: unhandled inspector error:
{"code":-32000,"message":"Node with given id does not belong to the document"}
```

| PR | Test that failed |
|---|---|
| #93 | `PositionedDragTest#test_a_failed_reposition_request_puts_the_row_back` |
| #97 | `OrgPortal::DirtyFormGuardWidgetTest#test_editing_a_field_then_reverting_it_does_not_prompt` |
| #97 (re-run) | `OrgPortal::NestedInputRestoreTest` |

Three different tests, one error — so it was never test-specific.

## Root cause

Turbo Drive renders a visit by parsing the response into a **separate document**, then adopting it into the live one — `activateNewBody()` calls `document.adoptNode`. A Capybara query that is mid-flight when that lands holds element handles whose `ownerDocument` just changed, and chromedriver rejects them.

Capybara already copes with "the DOM moved under me" by **retrying**: `synchronize` re-runs the block for every error in `driver.invalid_element_errors`, which includes `StaleElementReferenceError`.

I tested each way a node can be invalidated:

| Disruption | Error raised | Retried by Capybara? |
|---|---|---|
| detach children | `StaleElementReferenceError` | ✅ |
| replace `documentElement` | `StaleElementReferenceError` | ✅ |
| real navigation | `StaleElementReferenceError` | ✅ |
| `pushState` + wipe | `StaleElementReferenceError` | ✅ |
| **adopt into another document** | **`UnknownError`** | ❌ |

Cross-document adoption — precisely what Turbo does — is the one variant chromedriver reports differently, so it escapes the retry loop and fails the test outright.

## The fix

Classify it as retryable, restoring the behaviour Capybara already intends. Capybara does exactly this for `InvalidSelectorError` ("Work around chromedriver go_back/go_forward race condition").

It has to be the error **class**, because `catch_error?` matches with `is_a?` — a message-scoped matcher is never consulted. A genuine persistent `UnknownError` therefore still fails the test, just after the query's wait expires rather than immediately.

## Verification

Built a reproduction modelling one adoption racing one assertion (my first attempt churned the DOM every animation frame, which no retry-based fix can survive — that reproduction was wrong, and its results misleading):

```
unpatched (current CI behaviour)   cross-document failures = 5 / 40
patched (classified retryable)     cross-document failures = 0 / 40
```

- Full system suite green on **Rails 7 (29 tests)** and **Rails 8.1 (29 tests)**; lint clean.
- The regression test is driver-level, not browser-level — asserting on the race itself would be flaky. It fails if the patch is removed (verified by removing it).
- It also pins the `is_a?` assumption: if Capybara ever switches `catch_error?` to `===`, the test says to narrow the patch to the specific message.

## Scope

Test-harness only — nothing in `lib/` changes, so app runtime is untouched. Apps using Plutonium with Turbo can hit the same race in their own system tests; worth considering for `Plutonium::Testing` later, but shipping a Capybara monkeypatch to users is a bigger call than this fix needs to make.
