### PR TITLE
feat(wizard): install generator, sweep concurrency, and an experimental template

### DIFF
--- a/.claude/skills/plutonium-async-interactions/SKILL.md
+++ b/.claude/skills/plutonium-async-interactions/SKILL.md
@@ -12,7 +12,7 @@ For everything about the interaction itself (inputs, validation, outcomes, `exec
 ## 🚨 Critical (read first)
 
 - **Experimental.** The DSL and behavior may change in a future release — same status as [[plutonium-wizard]] and [[plutonium-kanban]]. Fine to build on; expect to revisit it on upgrade.
-- **Enable the subsystem first.** `config.async_interactions.enabled = true` in `config/initializers/plutonium.rb`, then `rails db:migrate`. Off by default, so no `plutonium_async_runs` table otherwise.
+- **Enable the subsystem first.** `rails g pu:async_interactions:install --dest=<portal>` flips `config.async_interactions.enabled = true`, schedules `ReapJob`, and connects the run resource to that portal; then `rails db:migrate`. Pass `--skip-portal` to enable it before any portal exists. Off by default, so no `plutonium_async_runs` table otherwise.
 - **`async` fully replaces `#execute`.** An interaction either executes inline or runs async — declaring both raises `ArgumentError` at load.
 - **Define `perform_on(record)` for targeted work, `perform` for opaque work.** A run class implementing neither fails loudly (naming the class) the first time it's performed, rather than a bare `NoMethodError`.
 - **A nested dispatch records its parent.** `parent_type`/`parent_id`/`parent_association` join initiator and tenant on the row, because `Policy#default_relation_scope` picks parent scoping **or** entity scoping, not both — a nested run missing its parent re-derives targets under the wider tenant scope, and any predicate reading `parent` silently answers false. A parent deleted mid-run refuses the run, exactly like a deleted tenant.

--- a/.claude/skills/plutonium-wizard/SKILL.md
+++ b/.claude/skills/plutonium-wizard/SKILL.md
@@ -11,7 +11,7 @@ For the field/input vocabulary used inside a step, load [[plutonium-resource]]. 
 
 ## 🚨 Critical (read first)
 
-- **Enable the subsystem first.** `config.wizards.enabled = true` in `config/initializers/plutonium.rb`, then `rails db:migrate`. It's `false` by default — without it there's no `plutonium_wizard_sessions` table.
+- **Enable the subsystem first.** `rails g pu:wizards:install` flips `config.wizards.enabled = true` and schedules `SweepJob`; then `rails db:migrate`. (By hand: the flag in `config/initializers/plutonium.rb`.) It's `false` by default — without it there's no `plutonium_wizard_sessions` table.
 - **Use bang methods** (`create!`/`update!`/`save!`) in `on_submit` and `execute`. Failure is signalled by a **raised exception** — a non-bang `false` advances the wizard and silently loses data. Or call `fail!("msg")`.
 - **`data` is step-keyed:** `data.<step>.<field>` (e.g. `data.company.name`, `data.plan.plan`). Each step has its own typed sub-object, so two steps may share a field name without colliding. Read a field through its owning step everywhere (`condition:`/`on_submit`/`execute`).
 - **`condition:` lambdas must be nil-safe.** They run against `data` at every transition, including before their deciding step is filled (value is `nil`). `-> { data.plan.plan == "pro" }` ✓; `-> { data.plan.plan.upcase == "PRO" }` raises on nil ✗.
@@ -20,7 +20,7 @@ For the field/input vocabulary used inside a step, load [[plutonium-resource]]. 
 - **No generator.** Author wizards by hand, like interactions. They live in `app/wizards/`.
 - **A wizard is a presentation object** — it's built with `view_context:`, so anything reachable only through `execute`/`on_submit` is reachable only from a wizard run. Logic may *start* there; the **second caller** (a job, an API, a rake task, the console) is the trigger to move it onto the **model**. See [[plutonium-behavior]] › Part 3 › Where the logic goes.
 - **Wizards are portal- *or* main-app-hosted.** A `register_wizard` mount inside a portal inherits the portal's auth/scoping/layout. A `register_wizard` mount on the **main app** runs standalone — for an **authenticated** main-app wizard you MUST define your own `::WizardsController` (include `Plutonium::Wizard::Controller` + your auth concern); the synthesized fallback is **bare (no auth)**. Resource-anchored (`wizard` macro) wizards always run embedded on the resource controller.
-- **Schedule `SweepJob`** (a periodic job/cron). It reaps abandoned/expired sessions — always good hygiene (stale `in_progress` rows pile up otherwise), and **load-bearing** for `on_submit`/`persist` wizards: it's the only thing that rolls back the partial domain records an abandoned save-as-you-go run leaves behind.
+- **Schedule `SweepJob`** — `pu:wizards:install` does it for you when Solid Queue is in the bundle; otherwise add a periodic job/cron yourself. It reaps abandoned/expired sessions — always good hygiene (stale `in_progress` rows pile up otherwise), and **load-bearing** for `on_submit`/`persist` wizards: it's the only thing that rolls back the partial domain records an abandoned save-as-you-go run leaves behind.
 
 ---
 
@@ -54,7 +54,7 @@ The ASK gate resolves the *design*; this confirms the app can actually *run* it.
 | Anchor model exists & reachable | Read the model an `anchored` wizard runs against | Missing/unreadable anchor ⇒ 404 / `NotAnchoredError` |
 | Host portal exists & its scoping | Read the portal engine (`scope_to_entity`?) + its real module name | Tenant folds into run identity; a guessed portal name breaks `register_wizard` |
 | Guest-flow prereqs | AR encryption keys if `encrypt_data`; no `concurrency_key`/`one_time` with `anonymous` | First write raises otherwise |
-| `on_submit` ⇒ SweepJob scheduled | The recurring-job config | Abandoned mid-flow records pile up forever |
+| `on_submit` ⇒ SweepJob scheduled | grep `config/recurring.yml` for `sweep_abandoned_wizards` | Abandoned mid-flow records pile up forever |
 
 **Don't author the class until `config.wizards.enabled` is confirmed and the anchor/target model + portal are read.** Until then, any class you show is provisional — say so; don't present a guessed field/column mapping as final.
 

--- a/docs/public/templates/experimental.rb
+++ b/docs/public/templates/experimental.rb
@@ -1,0 +1,34 @@
+# Plutonium's experimental subsystems: wizards and async interactions.
+#
+# Both are off by default — their flags gate their MIGRATIONS as well as their
+# behaviour, so an app that has not opted in has neither table. This turns them
+# on and schedules the recurring jobs each one needs to stay healthy.
+#
+# Kept out of plutonium.rb because it is the baseline install, and these two are
+# marked experimental: their DSL and behaviour may change in a future release.
+# Opting a new app in is a choice, not a default.
+after_bundle do
+  # SweepJob is the only thing that cleans up the partial domain records an
+  # abandoned `on_submit` wizard leaves behind. Unscheduled, those accumulate.
+  unless ENV["SKIP_WIZARDS"]
+    generate "pu:wizards:install"
+    git add: "."
+    git commit: %( -m 'chore: enable wizards') if `git status --porcelain`.present?
+  end
+
+  # --skip-portal: a fresh app has no portals yet, only main_app — the wrong home
+  # for the run resource in an app about to grow them. This turns the subsystem
+  # on; `rails g pu:async_interactions:install --dest=<portal>` connects the
+  # progress page and running banner once there is a portal worth naming.
+  unless ENV["SKIP_ASYNC_INTERACTIONS"]
+    generate "pu:async_interactions:install --skip-portal"
+    git add: "."
+    git commit: %( -m 'chore: enable async interactions') if `git status --porcelain`.present?
+  end
+
+  # Both gate their migration paths on the flags just written, and this process
+  # booted before either existed.
+  rails_command "db:migrate"
+  git add: "."
+  git commit: %( -m 'chore: migrate wizard + async run tables') if `git status --porcelain`.present?
+end

--- a/docs/public/templates/pluton8.rb
+++ b/docs/public/templates/pluton8.rb
@@ -14,4 +14,18 @@ after_bundle do
     "https://radioactive-labs.github.io/plutonium-core/templates/lite.rb"
   end
   rails_command "app:template LOCATION=#{lite_location}"
+
+  # Wizards + async interactions, last.
+  #
+  # After lite rather than straight after plutonium, because both of these
+  # schedule a recurring job and solid_queue — which lite installs — is what
+  # there is to schedule into. Run earlier and each would print "schedule it
+  # yourself", leaving the app with a subsystem nothing maintains and no second
+  # pass to fix it.
+  experimental_location = if ENV["LOCAL"]
+    "/Users/stefan/Documents/plutonium/plutonium-core/docs/public/templates/experimental.rb"
+  else
+    "https://radioactive-labs.github.io/plutonium-core/templates/experimental.rb"
+  end
+  rails_command "app:template LOCATION=#{experimental_location}"
 end

--- a/lib/generators/pu/async_interactions/install_generator.rb
+++ b/lib/generators/pu/async_interactions/install_generator.rb
@@ -12,21 +12,22 @@ module Pu
       source_root File.expand_path("templates", __dir__)
 
       desc(
-        "Connect Plutonium::Interaction::Async::Run to a portal, so its show page becomes routable\n\n" \
-        "e.g. rails g pu:async_interactions:install --dest=admin_portal"
+        "Enable async interactions, schedule the reaper, and connect the run resource to a portal\n\n" \
+        "e.g. rails g pu:async_interactions:install --dest=admin_portal\n" \
+        "     rails g pu:async_interactions:install --skip-portal   # app-wide only"
       )
 
       class_option :schedule, type: :string, default: "every 15 minutes",
         desc: "Cron-style schedule for the ReapJob recurring task"
 
+      class_option :skip_portal, type: :boolean, default: false,
+        desc: "Enable the subsystem without connecting the run resource to a portal"
+
       def start
-        @app_namespace = portal_option(:dest, prompt: "Select destination portal").camelize
-
-        template "app/controllers/async_runs_controller.rb", controller_path
-
-        register_resource_in_routes(routes_path, "Plutonium::Interaction::Async::Run")
-
+        enable_async_interactions
+        connect_portal unless options[:skip_portal]
         schedule_reap_job
+        migration_reminder
       rescue => e
         exception "#{self.class} failed:", e
       end
@@ -34,6 +35,37 @@ module Pu
       private
 
       attr_reader :app_namespace
+
+      # The flag gates the MIGRATION as well as the behaviour: while it is off
+      # the runs migration path is never registered, so plutonium_async_runs does
+      # not exist and dispatching raises NotEnabledError.
+      def enable_async_interactions
+        configure_plutonium "config.async_interactions.enabled = true"
+      end
+
+      # The half that needs somewhere to route to.
+      #
+      # Skippable because a fresh app has no portals yet — only main_app, which
+      # is the wrong home for a run resource in an app that is about to grow
+      # portals. So an installer running before any portal exists (a project
+      # template, say) can turn the subsystem on and leave connecting for later,
+      # when there is a portal worth naming.
+      def connect_portal
+        @app_namespace = portal_option(:dest, prompt: "Select destination portal").camelize
+
+        template "app/controllers/async_runs_controller.rb", controller_path
+        register_resource_in_routes(routes_path, "Plutonium::Interaction::Async::Run")
+      end
+
+      # Not run for you: the migration path is registered from the initializer at
+      # BOOT, and this process booted before the flag was written.
+      def migration_reminder
+        log :info, "async interactions enabled — run `rails db:migrate` to create plutonium_async_runs"
+        return unless options[:skip_portal]
+
+        log :info, "connect the run resource to a portal later: " \
+                   "rails g pu:async_interactions:install --dest=<portal>"
+      end
 
       # main_app is a valid destination (see PackageSelector#available_portals),
       # and it has neither a packages/ tree nor a Concerns::Controller to include.

--- a/lib/generators/pu/wizards/install_generator.rb
+++ b/lib/generators/pu/wizards/install_generator.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../lib/plutonium_generators"
+
+module Pu
+  module Wizards
+    # Turns the wizard subsystem on.
+    #
+    # App-wide, and takes no portal — unlike pu:async_interactions:install,
+    # which connects a RESOURCE and therefore needs somewhere to route it. A
+    # wizard mounts itself wherever it is declared (the `wizard` macro on a
+    # definition, or `register_wizard` in a portal or the main app), so there is
+    # nothing here to attach to a portal.
+    #
+    # What it does is the two steps every wizard app needs and neither of which
+    # a wizard can do for itself: flip the flag that registers the migration
+    # path, and schedule the sweep.
+    class InstallGenerator < Rails::Generators::Base
+      include PlutoniumGenerators::Generator
+      include PlutoniumGenerators::Concerns::ConfiguresRecurring
+
+      desc(
+        "Enable wizards and schedule the abandonment sweep\n\n" \
+        "e.g. rails g pu:wizards:install"
+      )
+
+      class_option :schedule, type: :string, default: "every 15 minutes",
+        desc: "Cron-style schedule for the SweepJob recurring task"
+
+      def start
+        enable_wizards
+        schedule_sweep_job
+        migration_reminder
+      rescue => e
+        exception "#{self.class} failed:", e
+      end
+
+      private
+
+      # The flag gates the MIGRATION as well as the behaviour: while it is off
+      # the wizard migration path is never registered, so
+      # plutonium_wizard_sessions does not exist and nothing works.
+      def enable_wizards
+        configure_plutonium "config.wizards.enabled = true"
+      end
+
+      # Idempotent via add_recurring_tasks, so re-running this is a no-op.
+      #
+      # Scheduling matters more than it looks. For an +execute+-only wizard an
+      # unscheduled sweep just leaves stale session rows, which is untidy; for an
+      # +on_submit+ wizard it is the only thing that cleans up the partial domain
+      # records an abandoned run left behind.
+      def schedule_sweep_job
+        if gem_in_bundle?("solid_queue")
+          unless add_recurring_tasks(sweep_job_task_yaml, marker: "sweep_abandoned_wizards")
+            log :skip, "SweepJob not scheduled (config/recurring.yml missing or already scheduled)"
+          end
+        else
+          log :info, "solid_queue not found — schedule Plutonium::Wizard::SweepJob yourself (see docs)"
+        end
+      end
+
+      def sweep_job_task_yaml
+        <<~YAML
+          sweep_abandoned_wizards:
+            class: Plutonium::Wizard::SweepJob
+            schedule: "#{options[:schedule]}"
+        YAML
+      end
+
+      # Not run for you: the migration path is registered from the initializer at
+      # BOOT, and this process booted before the flag was written.
+      def migration_reminder
+        log :info, "wizards enabled — run `rails db:migrate` to create plutonium_wizard_sessions"
+      end
+    end
+  end
+end

--- a/lib/plutonium/wizard/sweep_job.rb
+++ b/lib/plutonium/wizard/sweep_job.rb
@@ -19,6 +19,22 @@ module Plutonium
     # and an unconstantizable wizard class is skipped while the row is still reaped.
     # +completed+ rows are never touched (the +sweepable+ scope excludes them).
     class SweepJob < ActiveJob::Base
+      # One sweep at a time, when the host's queue offers a semaphore.
+      #
+      # A sweep that outlives its own interval would otherwise overlap the next
+      # tick and walk the same rows. That is not merely wasteful here: two
+      # sweepers can pick up the same session and both build a Runner for it, so
+      # a step's on_rollback compensator — refund the charge, call the external
+      # API — runs twice for one abandoned run.
+      #
+      # A constant key: every sweep is the same sweep, so they queue behind each
+      # other globally rather than per row. Only +key+ and +to+ are passed;
+      # +on_conflict+ arrived in Solid Queue 1.2 and passing it would turn an
+      # older host's boot into an ArgumentError.
+      if respond_to?(:limits_concurrency)
+        limits_concurrency to: 1, key: ->(*) { "sweep" }
+      end
+
       def perform(now: Time.current)
         store = Store::ActiveRecord.new
 

--- a/test/generators/async_interactions_install_generator_test.rb
+++ b/test/generators/async_interactions_install_generator_test.rb
@@ -12,28 +12,39 @@ class AsyncInteractionsInstallGeneratorTest < Rails::Generators::TestCase
 
   def setup
     git_restore_dummy_app
-    @portal_dir = destination_root.join("packages/test_portal")
-    FileUtils.mkdir_p(@portal_dir.join("config"))
-    FileUtils.mkdir_p(@portal_dir.join("app/controllers/test_portal/concerns"))
+    @portal_dirs = []
+    create_portal!("test_portal")
+  end
 
-    File.write(@portal_dir.join("config/routes.rb"), <<~RUBY)
-      TestPortal::Engine.routes.draw do
+  def teardown
+    @portal_dirs.each { |dir| FileUtils.rm_rf(dir) }
+  end
+
+  # A portal is any package whose name ends in _portal or _app
+  # (PackageSelector#available_portals), so a bare directory with routes and a
+  # Concerns::Controller is enough for --dest to resolve without prompting.
+  def create_portal!(name)
+    dir = destination_root.join("packages/#{name}")
+    @portal_dirs << dir
+    FileUtils.mkdir_p(dir.join("config"))
+    FileUtils.mkdir_p(dir.join("app/controllers/#{name}/concerns"))
+
+    File.write(dir.join("config/routes.rb"), <<~ROUTES)
+      #{name.camelize}::Engine.routes.draw do
         # register resources above.
       end
-    RUBY
+    ROUTES
 
-    File.write(@portal_dir.join("app/controllers/test_portal/concerns/controller.rb"), <<~RUBY)
-      module TestPortal
+    File.write(dir.join("app/controllers/#{name}/concerns/controller.rb"), <<~CONTROLLER)
+      module #{name.camelize}
         module Concerns
           module Controller
           end
         end
       end
-    RUBY
-  end
+    CONTROLLER
 
-  def teardown
-    FileUtils.rm_rf(@portal_dir) if @portal_dir&.exist?
+    dir
   end
 
   test "registers Plutonium::Interaction::Async::Run and generates a controller with controller_for" do
@@ -89,6 +100,34 @@ class AsyncInteractionsInstallGeneratorTest < Rails::Generators::TestCase
     run_generator ["--dest=test_portal"]
 
     assert_no_file "config/recurring.yml"
+  end
+
+  # The generator IS the connect step: there is no separate :connect. An app
+  # bootstrapped with --skip-portal, or one that grows a second portal later,
+  # re-runs install against the new --dest. Everything already done has to
+  # no-op, or the second run duplicates the enable line and the reaper.
+  test "a second run against another portal connects it and repeats nothing" do
+    create_portal!("second_portal")
+    File.write(destination_root.join("config/recurring.yml"), "production:\n")
+
+    run_generator ["--dest=test_portal"]
+    run_generator ["--dest=second_portal"]
+
+    %w[test_portal second_portal].each do |portal|
+      assert_file "packages/#{portal}/config/routes.rb" do |content|
+        assert_equal 1, content.scan("register_resource ::Plutonium::Interaction::Async::Run").size,
+          "#{portal} must register the run exactly once"
+      end
+      assert_file "packages/#{portal}/app/controllers/#{portal}/async_runs_controller.rb"
+    end
+
+    # App-wide, so the second portal must not restate them.
+    assert_file "config/initializers/plutonium.rb" do |content|
+      assert_equal 1, content.scan("config.async_interactions.enabled = true").size
+    end
+    assert_file "config/recurring.yml" do |content|
+      assert_equal 1, content.scan("reap_stalled_async_runs:").size
+    end
   end
 end
 

--- a/test/generators/async_interactions_install_generator_test.rb
+++ b/test/generators/async_interactions_install_generator_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 require "rails/generators/test_case"
 require "generators/pu/async_interactions/install_generator"
 
-class RunsInstallGeneratorTest < Rails::Generators::TestCase
+class AsyncInteractionsInstallGeneratorTest < Rails::Generators::TestCase
   include GeneratorTestHelper
 
   tests Pu::AsyncInteractions::InstallGenerator
@@ -100,18 +100,49 @@ end
 # app's own config/routes.rb — a TRACKED file every other test in the suite
 # shares. available_portals always offers "main_app" regardless of
 # destination_root (it reads Rails.root), so --dest=main_app still resolves.
-class RunsInstallMainAppGeneratorTest < Rails::Generators::TestCase
+class AsyncInteractionsInstallMainAppGeneratorTest < Rails::Generators::TestCase
   tests Pu::AsyncInteractions::InstallGenerator
   destination File.expand_path("../../tmp/pu_runs_install_main_app", __dir__)
   setup :prepare_destination
 
   setup do
-    FileUtils.mkdir_p(File.join(destination_root, "config"))
+    FileUtils.mkdir_p(File.join(destination_root, "config/initializers"))
     File.write(File.join(destination_root, "config/routes.rb"), <<~RUBY)
       Rails.application.routes.draw do
         # register resources above.
       end
     RUBY
+    # Every real app has one — pu:core:install writes it — and the generator
+    # flips config.async_interactions.enabled in it.
+    File.write(File.join(destination_root, "config/initializers/plutonium.rb"), <<~RUBY)
+      Plutonium.configure do |config|
+        # Configure plutonium above.
+      end
+    RUBY
+  end
+
+  test "enables the subsystem" do
+    run_generator ["--dest=main_app"]
+
+    # The flag gates the MIGRATION as well as the behaviour, so an install that
+    # only wired the portal left the table uncreated and every dispatch raising.
+    assert_file "config/initializers/plutonium.rb" do |content|
+      assert_match(/config\.async_interactions\.enabled = true/, content)
+    end
+  end
+
+  test "--skip-portal enables without connecting a portal" do
+    run_generator ["--skip-portal"]
+
+    assert_file "config/initializers/plutonium.rb" do |content|
+      assert_match(/config\.async_interactions\.enabled = true/, content)
+    end
+    # A fresh app has no portal worth naming yet; main_app is the wrong home for
+    # a run resource in an app about to grow portals.
+    assert_no_file "app/controllers/async_runs_controller.rb"
+    assert_file "config/routes.rb" do |content|
+      refute_match(/register_resource/, content)
+    end
   end
 
   test "supports --dest=main_app" do

--- a/test/generators/wizards_install_generator_test.rb
+++ b/test/generators/wizards_install_generator_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/test_case"
+require "generators/pu/wizards/install_generator"
+
+# App-wide, and takes no portal — a wizard mounts itself wherever it is declared,
+# so unlike the run resource there is nothing here to route into a portal.
+#
+# Runs against a throwaway destination_root rather than test/dummy, because it
+# writes config/initializers/plutonium.rb and config/recurring.yml — tracked
+# files the rest of the suite shares.
+class WizardsInstallGeneratorTest < Rails::Generators::TestCase
+  tests Pu::Wizards::InstallGenerator
+  destination File.expand_path("../../tmp/pu_wizards_install", __dir__)
+  setup :prepare_destination
+
+  setup do
+    FileUtils.mkdir_p(File.join(destination_root, "config/initializers"))
+    File.write(File.join(destination_root, "config/initializers/plutonium.rb"), <<~RUBY)
+      Plutonium.configure do |config|
+        # Configure plutonium above.
+      end
+    RUBY
+  end
+
+  test "enables the subsystem" do
+    run_generator
+
+    # The flag gates the MIGRATION as well as the behaviour: while it is off the
+    # wizard migration path is never registered, so plutonium_wizard_sessions
+    # does not exist and nothing works.
+    assert_file "config/initializers/plutonium.rb" do |content|
+      assert_match(/config\.wizards\.enabled = true/, content)
+    end
+  end
+
+  test "schedules the sweep when solid_queue is in the bundle" do
+    File.write(File.join(destination_root, "Gemfile"), %(gem "solid_queue"\n))
+    File.write(File.join(destination_root, "config/recurring.yml"), "production:\n")
+
+    run_generator
+
+    assert_file "config/recurring.yml" do |content|
+      assert_match(/sweep_abandoned_wizards:/, content)
+      assert_match(/class: Plutonium::Wizard::SweepJob/, content)
+      assert_match(/schedule: "every 15 minutes"/, content)
+    end
+  end
+
+  test "--schedule overrides the cadence" do
+    File.write(File.join(destination_root, "Gemfile"), %(gem "solid_queue"\n))
+    File.write(File.join(destination_root, "config/recurring.yml"), "production:\n")
+
+    run_generator ["--schedule=every hour"]
+
+    assert_file "config/recurring.yml" do |content|
+      assert_match(/schedule: "every hour"/, content)
+    end
+  end
+
+  test "is idempotent — a second run does not duplicate the task" do
+    File.write(File.join(destination_root, "Gemfile"), %(gem "solid_queue"\n))
+    File.write(File.join(destination_root, "config/recurring.yml"), "production:\n")
+
+    run_generator
+    run_generator
+
+    assert_file "config/recurring.yml" do |content|
+      assert_equal 1, content.scan("sweep_abandoned_wizards:").size
+    end
+    assert_file "config/initializers/plutonium.rb" do |content|
+      assert_equal 1, content.scan("config.wizards.enabled = true").size
+    end
+  end
+
+  test "without solid_queue it still enables, and schedules nothing" do
+    File.write(File.join(destination_root, "Gemfile"), %(gem "rails"\n))
+
+    run_generator
+
+    # Enabling is the part that must happen either way; scheduling is the host's
+    # problem when there is no scheduler to write to.
+    assert_file "config/initializers/plutonium.rb" do |content|
+      assert_match(/config\.wizards\.enabled = true/, content)
+    end
+    assert_no_file "config/recurring.yml"
+  end
+end


### PR DESCRIPTION
Stacked on #100 — review that first.

## Summary

Three things, all about the two experimental subsystems being installable and safe to leave running.

## Sweep concurrency

`Wizard::SweepJob` declares a semaphore where the queue offers one, matching what `Async::ReapJob` already does.

This is not just wasted work. A sweep that outlives its own interval overlaps the next tick and walks the same rows — and two sweepers can pick up the same session and both build a `Runner` for it, so a step's `on_rollback` compensator (refund the charge, call the external API) runs **twice** for one abandoned run.

`key`/`to` only: `on_conflict` arrived in Solid Queue 1.2 and passing it would turn an older host's boot into an `ArgumentError`.

## `pu:wizards:install`

Does the two things every wizard app needs and a wizard cannot do for itself:

- flips `config.wizards.enabled = true` — the flag gates the **migration path**, not just behaviour, so an app that hasn't opted in has no `plutonium_wizard_sessions` at all;
- schedules `SweepJob` in `config/recurring.yml` when Solid Queue is in the bundle.

It takes **no portal**, unlike `pu:async_interactions:install`. A wizard mounts itself wherever it's declared (`wizard` macro, or `register_wizard` in a portal or the main app), so there is nothing here to route.

## `pu:async_interactions:install` gains two things

- **It flips its own flag.** It never did — you installed the controller and route, and dispatch still raised `NotEnabledError` until you edited the initializer by hand.
- **`--skip-portal`.** Connecting the run resource needs somewhere to route it, and a fresh app has only `main_app` — the wrong home in an app about to grow portals. So an installer running before any portal exists can turn the subsystem on and leave connecting for later, which is exactly what a project template needs.

## `experimental.rb`

A new template carrying both, wired into `pluton8.rb`.

Kept out of `plutonium.rb` because that is the baseline install and these two are marked experimental — opting a new app in is a choice, not a default.

Runs **after** `lite.rb` rather than straight after `plutonium.rb`: both installers schedule a recurring job, and `solid_queue` — which lite installs — is what there is to schedule into. Run earlier and each would print "schedule it yourself", leaving the app with a subsystem nothing maintains and no second pass to fix it. `SKIP_WIZARDS` / `SKIP_ASYNC_INTERACTIONS` opt out, matching lite's convention.

It ends with `db:migrate`, since both gate their migration paths on flags written in that same process — after boot.

## A gap this turned up

`test/generators/async_interactions_install_generator_test.rb` still required `generators/pu/runs/install_generator`, stale since the rename on #99. It has been **silently not running**: `rake test` excludes `test/generators/**` (they live under `rake test_generators`), so nothing surfaced it. Fixed, along with the class names.

Worth knowing generally: "full suite green" from `rake test` says nothing about the generators.

## Test plan

- [x] `rake test_generators` — 34 suites, 0 failures, 0 errors (including 5 new for `pu:wizards:install` and 2 new for `--skip-portal` / flag-flipping)
- [x] `rake test` — 3123 tests, 0 failures, 0 errors
- [x] `standardrb` clean; `yarn docs:build` clean
- [x] Generator idempotence covered: a second run duplicates neither the recurring task nor the config line
- [x] The no-Solid-Queue path covered: still enables, schedules nothing, writes no `recurring.yml`

Skills updated: both now name their installer as the first step rather than describing the manual edit.
