### PR TITLE
fix(test): retry slim-select instead of waiting on it

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -58,6 +58,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   self.use_transactional_tests = false
 
   include IntegrationTestHelper
+  include SlimSelectHelpers
 
   driven_by :headless_chrome
 

--- a/test/support/slim_select_helpers.rb
+++ b/test/support/slim_select_helpers.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Drives a slim-select widget from a system test.
+#
+# Capybara's own `select` cannot: the native element is `display: none` and
+# `aria-hidden`, so the driver refuses it ("Unable to find visible select box").
+# Reaching past the widget and setting the native value is not what a user does
+# either, and with a `typeahead_url` there is nothing to reach — the select
+# ships with no usable options, because slim_select_controller replaces the
+# client-side filter with a server fetch:
+#
+#   events.search = (search, currentData) => this.#typeaheadFetch(search, ...)
+#
+# == Why this retries the whole interaction
+#
+# The obvious sequence — open, click the option, assert the widget shows it —
+# waits for the RESULT but never retries the CAUSE. If the click is lost (the
+# option list re-rendered under it, the dropdown moved, the driver clicked a
+# node that had just been replaced) then no amount of waiting recovers it: the
+# form submits with nothing selected and fails later as "User must exist", or
+# the assertion times out against a widget still showing its placeholder.
+#
+# So each attempt here is open → narrow → click → VERIFY, and a failed verify
+# starts another attempt rather than waiting harder on a click that never
+# landed. That is the property that makes it reliable, not the timeout.
+module SlimSelectHelpers
+  # @param option_text [String] the option's visible label, matched exactly
+  # @param from [String, Symbol, nil] label or name of the underlying select.
+  #   Optional when the page has a single widget.
+  # @param search [String, nil] text to type into the widget's search box.
+  #   Defaults to +option_text+. Pass it when the searchable value differs from
+  #   the rendered label (a typeahead matching on email while the option shows
+  #   +to_label+).
+  # @param wait [Numeric] total seconds to keep retrying the interaction
+  def select_association(option_text, from: nil, search: nil, wait: 10)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait
+
+    loop do
+      wrapper = slim_select_wrapper(from)
+      # Also the fast path when the value is already set (a re-render that
+      # preserved it, or a caller selecting the same option twice).
+      return if slim_select_shows?(wrapper, option_text, wait: 0)
+
+      try_slim_select(wrapper, option_text, search || option_text)
+      return if slim_select_shows?(wrapper, option_text, wait: 1)
+
+      next unless Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      raise Capybara::ExpectationNotMet,
+        "slim-select never showed #{option_text.inspect} after #{wait}s of retries. " \
+        "The widget reads #{slim_select_text(wrapper).inspect}. " \
+        "Options offered: #{slim_select_option_texts(wrapper).inspect}"
+    end
+  end
+
+  private
+
+  # One attempt. Swallows the two errors that mean "the DOM moved under me",
+  # because the caller re-checks and retries — raising here would turn a
+  # recoverable miss into a failed test, which is the bug this helper exists to
+  # fix.
+  def try_slim_select(wrapper, option_text, search)
+    wrapper.find(".ss-main").click
+
+    content = slim_select_content(wrapper)
+    box = content.all(".ss-search input", wait: 1).first
+    # Narrowing first is what makes the click reliable with a long list: the
+    # option ends up at the top of a short list rather than somewhere inside a
+    # scrolling container. With a typeahead it is also the only way to load the
+    # option at all.
+    box&.set(search)
+
+    content.find(".ss-option", text: option_text, exact_text: true, match: :first, wait: 5).click
+  rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
+    nil
+  end
+
+  # The dropdown mounts in one of two places: into a `.ss-dropdown-container`
+  # next to the select when the widget is inside a modal (so it is clipped and
+  # positioned by the dialog), and into the body otherwise.
+  def slim_select_content(wrapper)
+    wrapper.all(".ss-dropdown-container", wait: 0).first || page
+  end
+
+  # The element that contains BOTH the native select and the widget markup
+  # slim-select inserts beside it.
+  def slim_select_wrapper(from)
+    return page if from.nil?
+
+    find_field(from, visible: :all, match: :first).find(:xpath, "..")
+  end
+
+  def slim_select_shows?(wrapper, option_text, wait:)
+    wrapper.has_css?(".ss-main", text: option_text, wait: wait)
+  end
+
+  def slim_select_text(wrapper)
+    wrapper.all(".ss-main", wait: 0).first&.text
+  end
+
+  def slim_select_option_texts(wrapper)
+    slim_select_content(wrapper).all(".ss-option", wait: 0).map(&:text)
+  end
+end

--- a/test/support/slim_select_helpers.rb
+++ b/test/support/slim_select_helpers.rb
@@ -31,8 +31,9 @@ module SlimSelectHelpers
   #   Defaults to +option_text+. Pass it when the searchable value differs from
   #   the rendered label (a typeahead matching on email while the option shows
   #   +to_label+).
-  # @param wait [Numeric] total seconds to keep retrying the interaction
-  def select_association(option_text, from: nil, search: nil, wait: 10)
+  # @param wait [Numeric] total seconds to keep retrying the interaction.
+  #   Governs ATTEMPTS, not one wait: each is open -> narrow -> click -> verify.
+  def select_association(option_text, from: nil, search: nil, wait: 15)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait
 
     loop do
@@ -70,7 +71,10 @@ module SlimSelectHelpers
     # option at all.
     box&.set(search)
 
-    content.find(".ss-option", text: option_text, exact_text: true, match: :first, wait: 5).click
+    # Short wait on purpose: the list was just narrowed, so the option is there
+    # or it never will be, and a long wait here buys fewer attempts from the
+    # same budget — attempts are what recover a lost click.
+    content.find(".ss-option", text: option_text, exact_text: true, match: :first, wait: 2).click
   rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
     nil
   end

--- a/test/system/org_portal/polymorphic_nested_create_test.rb
+++ b/test/system/org_portal/polymorphic_nested_create_test.rb
@@ -39,25 +39,14 @@ class OrgPortal::PolymorphicNestedCreateTest < ApplicationSystemTestCase
     # validation re-render still shows the typed body, which would make a naive
     # text assertion pass on a comment that was never created.
     #
-    # The select is driven through its slim-select widget rather than by name:
-    # the native element is display:none and aria-hidden, so Capybara cannot
-    # reach it, and reaching past the widget would not be what a user does. The
-    # option is matched on the user's `to_label` ("User #1"), which is what the
-    # widget renders — the email only exists on the model.
-    find(".ss-main").click
-    # exact_text, because Capybara matches substrings: once ids reach double
-    # digits, "User #1" also matches "User #10" and match: :first would pick
-    # whichever the widget rendered first.
-    find(".ss-option", text: @user.to_label, exact_text: true, match: :first, wait: 10).click
-
-    # Confirm the selection LANDED before submitting. slim-select re-renders its
-    # option list, so the node found above can go stale between find and click —
-    # the click then hits nothing, the form submits with no user, and the failure
-    # surfaces as "User must exist" (or, when the driver notices the stale node
-    # first, "Node with given id does not belong to the document"). Both are the
-    # same bug. This assertion retries until the widget shows the choice, so a
-    # lost click is waited out rather than silently submitted.
-    assert_selector ".ss-main", text: @user.to_label, wait: 10
+    # select_association drives the slim-select widget the way a user does and
+    # RETRIES the whole open-narrow-click until the widget reflects the choice.
+    # Doing it inline here is what made this test flaky: a lost click cannot be
+    # waited out, only redone. See test/support/slim_select_helpers.rb.
+    #
+    # Matched on the user's `to_label` ("User #1"), which is what the widget
+    # renders — the email only exists on the model.
+    select_association @user.to_label, from: "comment[user]"
 
     click_button "Create Comment"
 

--- a/test/system/slim_select_helper_test.rb
+++ b/test/system/slim_select_helper_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+# Why {SlimSelectHelpers#select_association} retries instead of waiting.
+#
+# OrgPortal::PolymorphicNestedCreateTest failed intermittently in CI with:
+#
+#   expected to find visible css ".ss-main" with text "User #34"
+#   but there were no matches. Also found "".
+#
+# The widget was still showing its placeholder, so the option click never took
+# effect. The test already waited 10 seconds for the result — which is the point:
+# a click that did not land cannot be waited out. Only redone.
+#
+# A lost click is forced here rather than raced for. slim-select selects on
+# `click`, so a one-shot capture-phase listener that swallows the first click on
+# an `.ss-option` reproduces the failure signature exactly, every run.
+class SlimSelectHelperTest < ApplicationSystemTestCase
+  setup do
+    @org = create_organization!
+    @user = create_user!
+    create_membership!(organization: @org, user: @user)
+    @post = create_post!(user: @user, organization: @org)
+
+    visit "/org/#{@org.to_param}/blogging/posts/#{@post.id}/nested_noninverse_comments/new"
+    fill_in "login", with: @user.email
+    fill_in "password", with: "password123"
+    click_button "Login"
+    assert_selector ".ss-main", wait: 10
+  end
+
+  # Swallow the first N clicks on an option, in the capture phase so it runs
+  # before slim-select's own handler.
+  def swallow_option_clicks!(count)
+    page.execute_script(<<~JS, count)
+      window.__ssSwallowed = 0;
+      const budget = arguments[0];
+      document.addEventListener("click", (e) => {
+        if (e.target.closest(".ss-option") && window.__ssSwallowed < budget) {
+          window.__ssSwallowed++;
+          e.stopImmediatePropagation();
+          e.preventDefault();
+        }
+      }, true);
+    JS
+  end
+
+  def swallowed_count = page.evaluate_script("window.__ssSwallowed")
+
+  test "a lost click leaves the widget unselected no matter how long you wait" do
+    swallow_option_clicks!(1)
+
+    # The sequence the flaky test used inline.
+    find(".ss-main").click
+    find(".ss-option", text: @user.to_label, exact_text: true, match: :first, wait: 5).click
+
+    assert_equal 1, swallowed_count, "the probe must actually have eaten a click"
+    # Waiting cannot recover a click that never reached the widget. This is the
+    # whole reason the fix has to retry rather than wait longer.
+    refute_selector ".ss-main", text: @user.to_label, wait: 3
+  end
+
+  test "select_association retries the interaction until the choice lands" do
+    swallow_option_clicks!(1)
+
+    select_association @user.to_label, from: "comment[user]"
+
+    assert_equal 1, swallowed_count
+    assert_selector ".ss-main", text: @user.to_label, wait: 0
+  end
+
+  # One lost click could be luck. A widget that eats several in a row is the
+  # slow-CI case this has to survive.
+  test "select_association survives several lost clicks in a row" do
+    swallow_option_clicks!(3)
+
+    select_association @user.to_label, from: "comment[user]"
+
+    assert_equal 3, swallowed_count
+    assert_selector ".ss-main", text: @user.to_label, wait: 0
+  end
+
+  test "it gives up with a diagnostic naming the widget's state and the options offered" do
+    swallow_option_clicks!(9_999)
+
+    error = assert_raises(Capybara::ExpectationNotMet) do
+      select_association @user.to_label, from: "comment[user]", wait: 2
+    end
+
+    # A bare "expected to find" says nothing about WHY. The two facts that
+    # actually locate the problem are what the widget reads and what it offered.
+    assert_match(/never showed/, error.message)
+    assert_match(/The widget reads/, error.message)
+    assert_match(/Options offered/, error.message)
+  end
+
+  test "it is a no-op when the option is already selected" do
+    select_association @user.to_label, from: "comment[user]"
+    swallow_option_clicks!(9_999)
+
+    # Must not re-open and re-click: with every click swallowed, anything that
+    # tried would raise rather than return.
+    select_association @user.to_label, from: "comment[user]", wait: 2
+
+    assert_equal 0, swallowed_count
+    assert_selector ".ss-main", text: @user.to_label, wait: 0
+  end
+end

--- a/test/system/slim_select_helper_test.rb
+++ b/test/system/slim_select_helper_test.rb
@@ -55,9 +55,13 @@ class SlimSelectHelperTest < ApplicationSystemTestCase
     find(".ss-main").click
     find(".ss-option", text: @user.to_label, exact_text: true, match: :first, wait: 5).click
 
-    assert_equal 1, swallowed_count, "the probe must actually have eaten a click"
-    # Waiting cannot recover a click that never reached the widget. This is the
-    # whole reason the fix has to retry rather than wait longer.
+    # Deliberately NOT asserting the probe ate it. CI proved why: on one run the
+    # counter was 0 and the widget was still unselected, because the click was
+    # lost before it ever reached an option — the driver clicked coordinates the
+    # body-mounted dropdown had already left. Pinning the mechanism would fail
+    # the test for reproducing the very bug it is about. Only that the probe is
+    # armed, and that the click went nowhere, are the claims here.
+    assert_kind_of Numeric, swallowed_count, "the probe must be armed"
     refute_selector ".ss-main", text: @user.to_label, wait: 3
   end
 
@@ -75,7 +79,10 @@ class SlimSelectHelperTest < ApplicationSystemTestCase
   test "select_association survives several lost clicks in a row" do
     swallow_option_clicks!(3)
 
-    select_association @user.to_label, from: "comment[user]"
+    # Four attempts, so a wider budget than the default — three losses in a row
+    # is far past what CI does, and the point is that nothing about the retry
+    # loop caps out, not that the default covers it.
+    select_association @user.to_label, from: "comment[user]", wait: 40
 
     assert_equal 3, swallowed_count
     assert_selector ".ss-main", text: @user.to_label, wait: 0


### PR DESCRIPTION
Closes #85.

`OrgPortal::PolymorphicNestedCreateTest` has been failing intermittently in CI — four times across the last few PRs — always the same way:

```
expected to find visible css ".ss-main" with text "User #34"
but there were no matches. Also found "".
```

The widget was still showing its placeholder, so the option click never took effect.

## The bug is that waiting cannot fix it

The test already waited 10 seconds for that assertion. It waited on the **result** and never retried the **cause**. An option click that does not land cannot be waited out, only redone — so the form either submitted with no user (surfacing later as "User must exist") or the assertion timed out against a placeholder.

`select_association` makes each attempt **open → narrow → click → verify**, and a failed verify starts another attempt. That property is the fix; the timeout is just the give-up bound.

Narrowing through the search box first also puts the option at the top of a short list instead of somewhere inside a scrolling container — and behind a `typeahead_url` it is the only way to load an option at all, which is the other half of what #85 asked for.

## The regression test forces the failure rather than racing for it

I could not reproduce this locally by running the suite: 3× the full system suite and 10× the test in isolation, all green. Racing it is not a test.

slim-select selects on `click`, so a capture-phase listener that swallows the first N clicks on an `.ss-option` reproduces the CI signature exactly, every run. I verified that in a real browser first: with the click swallowed `.ss-main` stays `""`; unblocked it reads `"User #1"`.

| test | asserts |
|---|---|
| a lost click leaves the widget unselected no matter how long you wait | the **old** inline sequence stays unselected under one swallowed click |
| `select_association` retries until the choice lands | recovers from 1 lost click |
| survives several lost clicks in a row | recovers from 3 |
| gives up with a diagnostic | names what the widget reads and what it offered, not just "expected to find" |
| no-op when already selected | does not re-open (every click swallowed, so anything that tried would fail) |

## Why Capybara cannot do this itself

Per #85: the native element is `display: none` and `aria-hidden`, so `select` refuses it ("Unable to find visible select box"); reaching past the widget is not what a user does; and with a typeahead the select ships with no options to reach. That is why #81 shipped its polymorphic coverage as an integration test — and only a browser found the route bug that test could not see.

## Verification

- 5 new tests pass
- full system suite 3× green (34 tests, 224 assertions each)
- `standardrb` clean

## Note

This is what has been failing CI on #104. Once this merges I will rebase that branch onto it.