### PR TITLE
fix: apply an association's scope when creating through a nested route

### DIFF
--- a/.claude/skills/plutonium-tenancy/SKILL.md
+++ b/.claude/skills/plutonium-tenancy/SKILL.md
@@ -329,10 +329,17 @@ When the controller is hit through a nested route:
 
 1. **Resolves the parent** via `current_parent`, authorized for `:read?`.
 2. **Scopes queries** via parent association (e.g. `parent.properties` for `has_many`, `where(foreign_key => parent.id)` for `has_one`).
-3. **Assigns parent** on create (injected into `resource_params`).
+3. **Assigns parent** on create (injected into `resource_params`). The record is built
+   on the parent's association (`parent.properties.new`), so a scoped association
+   contributes its equality conditions as defaults.
 4. **Hides parent field** in forms (already determined by URL).
 
 You don't need to add hidden parent fields in forms or filter queries manually.
+
+Expose a scoped association as a nested route only when its scope is equality-based
+(`-> { where(published: true) }`). Rails derives create attributes from equality
+conditions alone, so `-> { where("expires_at > ?", Time.current) }` creates records
+that its own index, which honours the scope, will not list.
 
 ## Controller methods
 

--- a/docs/guides/nested-resources.md
+++ b/docs/guides/nested-resources.md
@@ -71,7 +71,8 @@ Plutonium prefixes nested routes with `nested_` so they don't conflict with top-
 
 1. **Resolves the parent** via `current_parent`, authorized for `:read?`.
 2. **Scopes queries** via the parent association (`company.properties` for `has_many`; `where(company_id: ...)` for `has_one`).
-3. **Assigns the parent** on create (injected into `resource_params`).
+3. **Assigns the parent** on create (injected into `resource_params`), building the
+   record on the parent's association so a scoped association supplies its defaults.
 4. **Hides the parent field** in forms and displays.
 
 No hidden fields. No manual scoping.

--- a/docs/reference/tenancy/nested-resources.md
+++ b/docs/reference/tenancy/nested-resources.md
@@ -53,7 +53,8 @@ When the controller is hit via a nested route, Plutonium automatically:
 2. **Scopes queries** via the parent association:
    - `has_many` → `parent.send(parent_association)` (e.g. `company.properties`)
    - `has_one` → `relation.where(foreign_key => parent.id)` with limit
-3. **Assigns the parent** on create (injected into `resource_params`).
+3. **Assigns the parent** on create (injected into `resource_params`), building the
+   record on the parent's association so a scoped association supplies its defaults.
 4. **Hides the parent field** in forms and displays (already determined by URL).
 
 You don't add hidden parent fields or filter queries manually.
@@ -164,6 +165,27 @@ resource_params
 ```
 
 No hidden parent fields needed in forms.
+
+### Scoped associations
+
+The record is built on the parent's association (`company.properties.new`), so an
+association that carries a scope contributes its equality conditions as defaults:
+
+```ruby
+class Company < ResourceRecord
+  has_many :published_properties, -> { where(published: true) },
+    class_name: "Property"
+end
+```
+
+Creating through `/companies/123/nested_published_properties` sets `published: true`.
+It has to: the index honours the same scope, so a record created without it is
+filtered out of the list it was created from.
+
+Only equality conditions become attributes. A scope like
+`-> { where("expires_at > ?", Time.current) }` cannot supply one, so an association
+scoped that way still creates records its own index will not list. Prefer an
+equality scope for any association you expose as a nested route.
 
 ## Presentation hooks
 

--- a/lib/plutonium/resource/controllers/crud_actions.rb
+++ b/lib/plutonium/resource/controllers/crud_actions.rb
@@ -38,7 +38,7 @@ module Plutonium
           authorize_current! resource_class
           set_page_title "Create #{resource_class.model_name.human.titleize}"
 
-          @resource_record = resource_class.new
+          @resource_record = build_resource_record
           maybe_apply_submitted_resource_params!
 
           render :new, formats: [:html]
@@ -49,7 +49,7 @@ module Plutonium
           authorize_current! resource_class
           set_page_title "Create #{resource_class.model_name.human.titleize}"
 
-          @resource_record = resource_class.new resource_params
+          @resource_record = build_resource_record resource_params
 
           respond_to do |format|
             if params[:pre_submit]
@@ -164,6 +164,34 @@ module Plutonium
         end
 
         private
+
+        # Builds the record that :new renders a form for and :create saves.
+        #
+        # Through a nested route it is built on the parent's association rather
+        # than on the class, so an association carrying a scope supplies that
+        # scope's attributes as defaults — exactly what `parent.things.new` does
+        # in Rails. The list side already honours the scope (the policy merges
+        # the relation into that same association), so building on the class
+        # instead produces a record the list filters straight back out: the
+        # create reports success and the row never appears.
+        #
+        # Only equality conditions carry over. `where(published: true)` becomes
+        # an attribute; `where("expires_at > ?", Time.current)` cannot, because
+        # that is all Rails derives create attributes from.
+        #
+        # The foreign key is still injected as an attribute by
+        # override_parent_params, which stays the authority for the value. This
+        # only adds what the association declares beyond it.
+        def build_resource_record(attributes = {})
+          return resource_class.new(attributes) unless current_parent
+
+          association = current_parent.class.reflect_on_association(current_nested_association)
+          if association.collection?
+            current_parent.public_send(current_nested_association).new(attributes)
+          else
+            current_parent.public_send(:"build_#{current_nested_association}", attributes)
+          end
+        end
 
         # Hook fired once, immediately after a successful create-save and BEFORE
         # the response is built. No-op by default. KanbanActions overrides it to

--- a/test/dummy/db/migrate/20260820000001_add_flagged_to_comments.rb
+++ b/test/dummy/db/migrate/20260820000001_add_flagged_to_comments.rb
@@ -1,0 +1,5 @@
+class AddFlaggedToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :flagged, :boolean, null: false, default: false
+  end
+end

--- a/test/dummy/packages/blogging/app/models/blogging/post.rb
+++ b/test/dummy/packages/blogging/app/models/blogging/post.rb
@@ -31,6 +31,12 @@ class Blogging::Post < Blogging::ResourceRecord
   # ends up naming the collection route with an _index suffix. Kept separate
   # from the one above so each test moves a single variable.
   has_many :comment_series, as: :commentable, class_name: "Comment", dependent: :destroy
+  # A nested association carrying a scope. The list side honours it (the policy
+  # merges the relation into `parent.flagged_comments`), so a record created
+  # through the route without the scope's attributes is filtered straight back
+  # out of the list it was created from.
+  has_many :flagged_comments, -> { where(flagged: true) }, as: :commentable,
+    class_name: "Comment", dependent: :destroy
   has_many :post_tags, class_name: "Blogging::PostTag", foreign_key: :post_id, dependent: :destroy
   has_many :tags, through: :post_tags, class_name: "Blogging::Tag"
   # add has_many associations above.

--- a/test/integration/org_portal/blogging_posts_test.rb
+++ b/test/integration/org_portal/blogging_posts_test.rb
@@ -103,6 +103,37 @@ class OrgPortal::BloggingPostsTest < ActionDispatch::IntegrationTest
     assert_equal post_record.class.polymorphic_name, comment.commentable_type
   end
 
+  # Creating through an association that carries a scope. The list side merges
+  # the relation into `parent.flagged_comments`, so a record built without the
+  # scope's attributes is filtered out of the very list it was created from:
+  # the create reports success and the row never appears.
+  test "creates through a scoped nesting with the scope's attributes applied" do
+    post_record = create_post!(user: @user, organization: @org)
+    body = "Created through the scoped nesting"
+
+    assert_difference -> { Comment.count }, 1 do
+      post "#{current_path_prefix}/blogging/posts/#{post_record.id}/nested_flagged_comments",
+        params: {comment: {body: body, user: @user.to_sgid.to_s}}
+    end
+
+    comment = Comment.order(:id).last
+    assert comment.flagged, "expected the association's scope to supply flagged: true"
+
+    # The symptom a user actually sees: it has to come back in that list.
+    get "#{current_path_prefix}/blogging/posts/#{post_record.id}/nested_flagged_comments"
+    assert_response :success
+    assert_match body, response.body
+  end
+
+  # The form for a scoped nesting is built from the same association, so the
+  # scope's attributes are already applied before anything is typed.
+  test "renders a new form through a scoped nesting" do
+    post_record = create_post!(user: @user, organization: @org)
+
+    get "#{current_path_prefix}/blogging/posts/#{post_record.id}/nested_flagged_comments/new"
+    assert_response :success
+  end
+
   # "comment_series" singularizes to itself, so Rails suffixes the collection
   # route with _index. The nested URL builder has to match that, as the
   # top-level one already does, or every link it builds for the collection
@@ -122,6 +153,20 @@ class OrgPortal::BloggingPostsTest < ActionDispatch::IntegrationTest
     create_post_detail!(post: post_record)
     get "#{current_path_prefix}/blogging/posts/#{post_record.id}/nested_post_detail"
     assert_response :success
+  end
+
+  # The singular counterpart of the nested create above: a has_one is built with
+  # `build_post_detail` rather than on a collection, so it takes the other branch.
+  test "creates through a has_one nesting" do
+    post_record = create_post!(user: @user, organization: @org)
+
+    assert_difference -> { Blogging::PostDetail.count }, 1 do
+      post "#{current_path_prefix}/blogging/posts/#{post_record.id}/nested_post_detail",
+        params: {blogging_post_detail: {seo_title: "Built through the has_one"}}
+    end
+
+    detail = Blogging::PostDetail.order(:id).last
+    assert_equal post_record.id, detail.post_id
   end
 
   test "lists post tags (has_many through)" do


### PR DESCRIPTION
A record created through a nested route got its foreign key set and nothing else the association declared.

```ruby
has_many :published_sections, -> { where(published: true) }, class_name: "Section"
```

Creating through `/…/nested_published_sections` produced a `Section` with the right `story_page_id` and `published` left at its default.

## Cause

The two sides of the same association disagreed.

The **list** side honours the scope. `Policy#relation_scope` merges the relation into the association itself:

```ruby
parent.public_send(parent_association).merge(relation)
```

The **write** side did not. The parent was injected into `resource_params` as an attribute by `override_parent_params`, and the record was then built with a bare `resource_class.new`. Reduced to the two calls, against a scoped association:

```
READ : SELECT "comments".* FROM "comments" WHERE commentable_id = 999
       AND commentable_type = 'Blogging::Post' AND "comments"."body" = 'FLAG'
WRITE: {"body" => nil, "commentable_id" => 999}
```

So the record was filtered straight back out of the list it had just been created from. The create reported success, the form gave no hint, and the row never appeared.

## Fix

The record is now built on the parent's association, which is what `parent.published_sections.new` does in Rails. Both construction sites go through one private method: `:new`, which renders the form, and `:create`, which saves.

```ruby
def build_resource_record(attributes = {})
  return resource_class.new(attributes) unless current_parent

  association = current_parent.class.reflect_on_association(current_nested_association)
  if association.collection?
    current_parent.public_send(current_nested_association).new(attributes)
  else
    current_parent.public_send(:"build_#{current_nested_association}", attributes)
  end
end
```

`override_parent_params` is untouched and stays the authority for the foreign key. This only adds what the association declares beyond it.

The throwaway `resource_class.new` in `submitted_resource_params` is deliberately left alone: it is the param-extraction record, and building it through the association would mutate the parent's in-memory association for a record that is discarded.

## The limit, documented rather than routed around

Only equality conditions carry over, because that is all Rails derives create attributes from:

```
via association: body="FLAG"   (where(body: "FLAG"))
non-equality:    body=nil      (where("length(body) > 3"))
```

`where(published: true)` becomes an attribute. `where("expires_at > ?", Time.current)` cannot, so an association scoped that way can still create records its own index will not list. That is stated on the nested-resources reference and guide and in the tenancy skill.

The issue also asked whether `routable_has_many_associations` should skip scoped associations until this was handled. It should not: most scopes in the wild are `-> { order(...) }`, which routes and creates correctly, and skipping every scoped association would delete a lot of working routes to fix a subset.

## Fixture

The dummy application had no scoped `has_many` at all, so there was nothing to regress against. This adds `flagged` to comments and a scoped association on `Blogging::Post`, following the `noninverse_comments` and `comment_series` precedent of associations that exist purely as routing fixtures. `flagged` is absent from `CommentPolicy`'s permitted attributes, so it stays out of every form and leaves the other tests untouched.

## Tests

Three, in `test/integration/org_portal/blogging_posts_test.rb`:

* the scoped create, asserting both the attribute and that the record comes back in the list it was created from (the symptom a user actually sees);
* the scoped `new` form;
* a `has_one` nested create. That one is a regression guard rather than a reproduction: nothing covered `has_one` nested creation before, and it takes the `build_<name>` branch.

Confirmed failing before the change, for the right reason:

```
FAIL OrgPortal::BloggingPostsTest#test_creates_through_a_scoped_nesting…
     expected the association's scope to supply flagged: true
```

## Verification

| version | tests | assertions | result |
| --- | --- | --- | --- |
| rails-8.1 | 3154 | 8159 | 0 failures, 0 errors |
| rails-8.0 | 3154 | 8159 | 0 failures, 0 errors |
| rails-7 | 3154 | 8103 | 0 failures, 0 errors |

`standardrb` clean on every changed file. `yarn docs:build` passes.

Closes #84
