### PR TITLE
feat(routing): declare which associations get nested routes

### DIFF
--- a/.claude/skills/plutonium-tenancy/SKILL.md
+++ b/.claude/skills/plutonium-tenancy/SKILL.md
@@ -323,6 +323,26 @@ Plutonium prefixes nested routes with `nested_` to avoid conflicts with the top-
 
 For `has_one`: index redirects to show (or new if no record exists); only one record per parent.
 
+### Choosing which associations get routes
+
+Every routable association gets a nested route unless the registration narrows it:
+
+```ruby
+register_resource ::Company, associations: %i[properties company_profile]
+```
+
+`associations: []` draws none. A name that is not a `has_many`/`has_one`, or whose
+child is not registered in that portal, raises at boot.
+
+`config.nested_association_routes = :declared` (default `:detected`) makes a resource
+that names none get none. The mode only changes what silence means; `associations:`
+behaves the same either way, and top-level routes are unaffected.
+
+**Before turning `:declared` on:** it is global, so every resource naming nothing
+loses its nested routes, and a policy's `permitted_associations` panel links to the
+nested route — permit an association there without declaring it here and the panel
+points nowhere.
+
 ## Automatic behavior in nested routes
 
 When the controller is hit through a nested route:

--- a/docs/guides/nested-resources.md
+++ b/docs/guides/nested-resources.md
@@ -67,6 +67,15 @@ Plutonium prefixes nested routes with `nested_` so they don't conflict with top-
 
 `has_one` associations get singular routes — index redirects to show (or new if no record exists).
 
+Every routable association gets one by default. To draw only some of them:
+
+```ruby
+register_resource ::Company, associations: %i[properties company_profile]
+```
+
+Set `config.nested_association_routes = :declared` to make that the rule, so a
+resource naming none gets none. See [Reference › Tenancy › Nested resources](/reference/tenancy/nested-resources#declaring-which-associations-get-routes).
+
 ## What Plutonium does automatically
 
 1. **Resolves the parent** via `current_parent`, authorized for `:read?`.

--- a/docs/reference/app/portals.md
+++ b/docs/reference/app/portals.md
@@ -128,6 +128,16 @@ For each call, Plutonium auto-generates:
 
 You list every resource the portal exposes. If a resource isn't registered, it has no URLs in that portal — `resource_url_for` will fail.
 
+### Choosing nested associations
+
+Name the associations that get nested routes, and the rest are not drawn:
+
+```ruby
+register_resource ::Post, associations: %i[comments post_detail]
+```
+
+`associations: []` draws none, and a name that is not a routable association fails the boot. Set `config.nested_association_routes = :declared` to make naming them the rule — see [Tenancy › Nested resources](../tenancy/nested-resources#declaring-which-associations-get-routes).
+
 ### Singular (singleton) resources
 
 For resources with no collection — a single per-user `Profile`, app-wide `Settings`, etc.:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,6 +41,7 @@ Loads the baseline defaults for a given framework version. Call this first; late
 | `auto_eager_load_collections` | `true` | Index pages, kanban boards and CSV exports preload the associations and attachments they render. Set `false` to disable globally, or override `auto_eager_load_collections?` in a controller. See [Performance](/guides/performance). |
 | `default_page_width` | `:md` | Width of detail-style pages — the show page and resource forms. One of `:sm :md :lg :xl :full` (`:full` = unconstrained). Index and table pages are unaffected. Override per-resource with `page_width` / `form_width` / `display_width`; see [Definition › Page width](./resource/definition#page-width). |
 | `wizards.width` | `:md` | Default width of wizard step pages. **Independent of `default_page_width`** — a wizard is a self-contained flow, so widening resource pages leaves wizards alone. Override per wizard with `width`. Same size tokens. |
+| `nested_association_routes` | `:detected` | Where a resource's nested routes come from. `:detected` draws one for every `has_many` / `has_one` whose child is registered. `:declared` draws only what `register_resource ..., associations:` names, so a resource that names none gets none. See [Nested resources › Declaring which associations get routes](./tenancy/nested-resources#declaring-which-associations-get-routes). |
 | `assets.logo` | `"plutonium.png"` | Brand logo asset. See [Assets](./ui/assets). |
 | `assets.favicon` | `"plutonium.ico"` | Favicon asset. |
 | `assets.stylesheet` | `"plutonium.css"` | Stylesheet entry. |

--- a/docs/reference/tenancy/nested-resources.md
+++ b/docs/reference/tenancy/nested-resources.md
@@ -45,6 +45,40 @@ For `has_one`:
 - Only one record can exist per parent.
 - Forms don't show the parent field (determined by URL).
 
+## Declaring which associations get routes
+
+By default every `has_many` and `has_one` whose child is a registered resource gets
+a nested route. Name the ones you want and the rest are not drawn:
+
+```ruby
+register_resource ::Company, associations: %i[properties company_profile]
+```
+
+`associations: []` draws none. Naming an association that is not a `has_many` or
+`has_one`, or whose child is not registered in that portal, fails the boot rather
+than quietly drawing one route fewer.
+
+To make declaring them the rule rather than the exception, flip the default so that
+a resource naming none gets none:
+
+```ruby
+# config/initializers/plutonium.rb
+Plutonium.configure do |config|
+  config.nested_association_routes = :declared   # default: :detected
+end
+```
+
+The mode only decides what silence means. `associations:` works the same either way,
+and top-level routes are untouched by both.
+
+Two things to know before turning it on:
+
+- It applies to every portal at once, and every resource that names nothing loses its
+  nested routes. On an existing app, expect to add `associations:` in several places.
+- A policy's `permitted_associations` renders a panel on the show page that links to
+  the nested route. An association permitted there but omitted here leaves that panel
+  pointing at a route that does not exist. The two lists have to agree.
+
 ## Automatic behavior on nested routes
 
 When the controller is hit via a nested route, Plutonium automatically:

--- a/lib/plutonium/configuration.rb
+++ b/lib/plutonium/configuration.rb
@@ -96,6 +96,39 @@ module Plutonium
       @normalized_default_phone_country = value&.downcase
     end
 
+    # Valid values for {#nested_association_routes}.
+    NESTED_ASSOCIATION_ROUTE_MODES = %i[detected declared].freeze
+
+    # @return [Symbol] where a resource's nested routes come from.
+    #
+    #   `:detected` (default) draws one for every `has_many` and `has_one` whose
+    #   child is a registered resource, which is how Plutonium has always behaved.
+    #
+    #   `:declared` draws only what `register_resource` names:
+    #
+    #     register_resource ::Post, associations: %i[comments post_detail]
+    #
+    #   A resource that names none then gets no nested routes at all. Naming
+    #   associations works in either mode; the mode only decides what silence means.
+    #
+    #   Note that a policy's `permitted_associations` renders a panel on the show
+    #   page that links to the nested route, so an association permitted there and
+    #   omitted here has a panel with nowhere to point.
+    attr_reader :nested_association_routes
+
+    # @param value [Symbol] one of {NESTED_ASSOCIATION_ROUTE_MODES}
+    # @raise [ArgumentError] on any other value, rather than silently drawing
+    #   the wrong route table for a typo.
+    def nested_association_routes=(value)
+      value = value.to_sym
+      unless NESTED_ASSOCIATION_ROUTE_MODES.include?(value)
+        raise ArgumentError, "unknown nested_association_routes #{value.inspect}. " \
+          "Valid modes: #{NESTED_ASSOCIATION_ROUTE_MODES.map(&:inspect).join(", ")}"
+      end
+
+      @nested_association_routes = value
+    end
+
     # Map of version numbers to their default configurations
     VERSION_DEFAULTS = {
       1.0 => proc do |config|
@@ -123,6 +156,7 @@ module Plutonium
       @navii_host_url = "https://api.navii.dev"
       @auto_eager_load_collections = true
       @default_page_width = :md
+      @nested_association_routes = :detected
     end
 
     # Load default configuration for a specific version

--- a/lib/plutonium/routing/mapper_extensions.rb
+++ b/lib/plutonium/routing/mapper_extensions.rb
@@ -34,6 +34,10 @@ module Plutonium
       #
       # @param resource [Class] The resource class to be registered.
       # @param options [Hash] Additional options for resource registration.
+      # @option options [Array<Symbol>] :associations the associations to draw
+      #   nested routes for. Omit to draw one for every routable association, or
+      #   set +Plutonium.configuration.nested_association_routes = :declared+ to
+      #   make omitting it mean none.
       # @yield An optional block for additional resource configuration.
       # @return [void]
       def register_resource(resource, options = {}, &)
@@ -101,7 +105,7 @@ module Plutonium
         concern route_config[:concern_name] do
           send route_config[:route_type], route_config[:route_name], **route_config[:route_options] do
             instance_exec(&route_config[:block]) if route_config[:block]
-            define_nested_resource_routes(resource)
+            define_nested_resource_routes(resource, route_config[:associations])
           end
         end
       end
@@ -109,12 +113,21 @@ module Plutonium
       # Defines nested resource routes for a given resource.
       #
       # @param resource [Class] The parent resource class.
+      # @param declared [Array<Symbol>, nil] the associations named by
+      #   register_resource, or nil when it named none.
       # @return [void]
-      def define_nested_resource_routes(resource)
+      def define_nested_resource_routes(resource, declared = nil)
+        allowed = nested_route_associations(resource, declared)
+
         # has_many associations use plural routes
         resource.routable_has_many_associations.each do |assoc_info|
+          next if allowed && !allowed.include?(assoc_info[:name])
+
           base_config = route_set.resource_route_config_for(assoc_info[:plural])[0]
-          next unless base_config
+          unless base_config
+            raise_unregistered_nested_association(resource, assoc_info) if declared
+            next
+          end
 
           # Register with association-based key: "parent_plural/association_name"
           # Force route_type: :resources — has_many associations always nest as a
@@ -139,8 +152,13 @@ module Plutonium
 
         # has_one associations use singular routes
         resource.routable_has_one_associations.each do |assoc_info|
+          next if allowed && !allowed.include?(assoc_info[:name])
+
           base_config = route_set.resource_route_config_for(assoc_info[:plural])[0]
-          next unless base_config
+          unless base_config
+            raise_unregistered_nested_association(resource, assoc_info) if declared
+            next
+          end
 
           # Register with association-based key and singular route type
           nested_key = "#{resource.model_name.plural}/#{assoc_info[:name]}"
@@ -161,6 +179,51 @@ module Plutonium
             define_singleton_method(:collection, original_collection)
           end
         end
+      end
+
+      # The associations a parent may draw nested routes for.
+      #
+      # nil means every routable association, which is what `:detected` does for
+      # a registration that named none. An array is a closed list, and an empty
+      # one is a real answer: `:declared` with nothing named draws nothing.
+      #
+      # A declared name that is not a routable association fails the boot. The
+      # whole point of naming them is to stop guessing which routes exist, so a
+      # typo that silently draws one route fewer would defeat it.
+      #
+      # @param resource [Class] The parent resource class.
+      # @param declared [Array<Symbol>, nil] the associations named at registration.
+      # @return [Array<Symbol>, nil]
+      # @raise [ArgumentError] if a declared name is not a routable association.
+      def nested_route_associations(resource, declared)
+        if declared.nil?
+          return nil if Plutonium.configuration.nested_association_routes == :detected
+
+          return []
+        end
+
+        routable = (resource.routable_has_many_associations +
+                    resource.routable_has_one_associations).map { |info| info[:name] }
+        unknown = declared - routable
+        if unknown.any?
+          raise ArgumentError,
+            "#{resource} is registered with `associations: #{declared.inspect}`, but " \
+            "#{unknown.map(&:inspect).join(", ")} #{(unknown.size == 1) ? "is not a" : "are not"} " \
+            "routable #{"association".pluralize(unknown.size)} on it. " \
+            "Available: #{routable.empty? ? "(none)" : routable.map(&:inspect).join(", ")}. " \
+            "Nested routes are drawn for has_many and has_one only."
+        end
+
+        declared
+      end
+
+      # @raise [ArgumentError] always
+      def raise_unregistered_nested_association(resource, assoc_info)
+        raise ArgumentError,
+          "#{resource} declares `associations: [:#{assoc_info[:name]}]`, but " \
+          "#{assoc_info[:klass]} is not registered in this portal, so there is no " \
+          "route to nest under it. Add `register_resource #{assoc_info[:klass]}` " \
+          "alongside it, or drop :#{assoc_info[:name]} from the list."
       end
 
       # Defines member-level interactive actions.

--- a/lib/plutonium/routing/route_set_extensions.rb
+++ b/lib/plutonium/routing/route_set_extensions.rb
@@ -151,6 +151,11 @@ module Plutonium
           route_type: options[:singular] ? :resource : :resources,
           route_name: route_name,
           concern_name: concern_name,
+          # The associations this resource draws nested routes for, or nil when
+          # the registration named none. nil is not "no associations": what
+          # silence means is decided by
+          # Plutonium.configuration.nested_association_routes.
+          associations: options[:associations]&.map(&:to_sym),
           route_options: {
             # model_name.collection, not resource.to_s.pluralize.underscore:
             # the latter reads the RAW class name, ignoring a model that pins

--- a/test/plutonium/routing/declared_nested_associations_test.rb
+++ b/test/plutonium/routing/declared_nested_associations_test.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A portal that exists only to be drawn at. Redrawing one of the dummy app's own
+# portals would mean restoring every engine from its routes file after each test,
+# which costs more than the rest of this file put together. Nothing mounts this
+# one, and nothing else reads its route set.
+module NestedRouteDrawPortal
+  class Engine < ::Rails::Engine
+    include Plutonium::Portal::Engine
+  end
+end
+
+module Plutonium
+  module Routing
+    # `register_resource ..., associations:` names the associations a resource
+    # draws nested routes for, and
+    # Plutonium.configuration.nested_association_routes decides what naming none
+    # means: `:detected` (every routable association, the historical behaviour)
+    # or `:declared` (nothing).
+    #
+    # These redraw a real portal engine rather than asserting against a mapper
+    # double, because what is under test is which routes come out the far end of
+    # a draw. StorefrontPortal is the smallest portal in the dummy app, and the
+    # teardown restores every engine from its own routes file.
+    class DeclaredNestedAssociationsTest < Minitest::Test
+      def setup
+        @original_mode = Plutonium.configuration.nested_association_routes
+      end
+
+      def teardown
+        Plutonium.configuration.nested_association_routes = @original_mode
+      end
+
+      def test_detected_mode_draws_every_routable_association
+        draw do
+          register_resource ::Blogging::Post
+          register_resource ::Comment
+          register_resource ::Blogging::PostDetail
+        end
+
+        assert_includes nested_keys, "blogging_posts/comments"
+        assert_includes nested_keys, "blogging_posts/post_detail"
+        # Named nowhere, drawn anyway: that is what :detected means.
+        assert_includes nested_keys, "blogging_posts/comment_series"
+      end
+
+      def test_declared_associations_are_the_only_ones_drawn
+        draw do
+          register_resource ::Blogging::Post, associations: %i[comments]
+          register_resource ::Comment
+          register_resource ::Blogging::PostDetail
+        end
+
+        assert_includes nested_keys, "blogging_posts/comments"
+        refute_includes nested_keys, "blogging_posts/comment_series"
+        refute_includes nested_keys, "blogging_posts/post_detail"
+      end
+
+      def test_declared_associations_cover_has_one
+        draw do
+          register_resource ::Blogging::Post, associations: %i[post_detail]
+          register_resource ::Comment
+          register_resource ::Blogging::PostDetail
+        end
+
+        assert_includes nested_keys, "blogging_posts/post_detail"
+        refute_includes nested_keys, "blogging_posts/comments"
+      end
+
+      # An empty list is an answer, not an omission.
+      def test_empty_declaration_draws_nothing
+        draw do
+          register_resource ::Blogging::Post, associations: []
+          register_resource ::Comment
+        end
+
+        assert_empty nested_keys
+      end
+
+      def test_declared_mode_draws_nothing_when_none_are_named
+        Plutonium.configuration.nested_association_routes = :declared
+
+        draw do
+          register_resource ::Blogging::Post
+          register_resource ::Comment
+          register_resource ::Blogging::PostDetail
+        end
+
+        assert_empty nested_keys
+      end
+
+      def test_declared_mode_still_draws_what_is_named
+        Plutonium.configuration.nested_association_routes = :declared
+
+        draw do
+          register_resource ::Blogging::Post, associations: %i[comments]
+          register_resource ::Comment
+        end
+
+        assert_equal ["blogging_posts/comments"], nested_keys
+      end
+
+      # Top-level routes are untouched by either mode.
+      def test_declared_mode_leaves_top_level_routes_alone
+        Plutonium.configuration.nested_association_routes = :declared
+
+        draw do
+          register_resource ::Blogging::Post
+          register_resource ::Comment
+        end
+
+        assert_includes route_keys, "blogging_posts"
+        assert_includes route_keys, "comments"
+      end
+
+      def test_unknown_association_fails_the_draw
+        error = assert_raises(ArgumentError) do
+          draw do
+            register_resource ::Blogging::Post, associations: %i[commets]
+            register_resource ::Comment
+          end
+        end
+
+        assert_match(/Blogging::Post is registered with/, error.message)
+        assert_match(/:commets is not a routable association/, error.message)
+        # Names what it could have meant.
+        assert_match(/:comments/, error.message)
+      end
+
+      # belongs_to and has_many :through are not nestable, so naming one is the
+      # same mistake as naming something that does not exist.
+      def test_belongs_to_is_not_a_routable_association
+        error = assert_raises(ArgumentError) do
+          draw do
+            register_resource ::Blogging::Post, associations: %i[user]
+            register_resource ::Comment
+          end
+        end
+
+        assert_match(/:user is not a routable association/, error.message)
+      end
+
+      # Silently skipped when detected; an explicit declaration says the author
+      # expected a route, so say why there is none.
+      def test_declaring_an_unregistered_child_fails_the_draw
+        error = assert_raises(ArgumentError) do
+          draw do
+            register_resource ::Blogging::Post, associations: %i[comments]
+          end
+        end
+
+        assert_match(/Comment is not registered in this portal/, error.message)
+        assert_match(/register_resource Comment/, error.message)
+      end
+
+      def test_configuration_rejects_an_unknown_mode
+        error = assert_raises(ArgumentError) do
+          Plutonium.configuration.nested_association_routes = :declaired
+        end
+
+        assert_match(/unknown nested_association_routes :declaired/, error.message)
+        assert_match(/:detected, :declared/, error.message)
+      end
+
+      def test_configuration_accepts_a_string
+        Plutonium.configuration.nested_association_routes = "declared"
+
+        assert_equal :declared, Plutonium.configuration.nested_association_routes
+      end
+
+      private
+
+      def draw(&block)
+        ::NestedRouteDrawPortal::Engine.routes.clear!
+        ::NestedRouteDrawPortal::Engine.routes.draw(&block)
+      end
+
+      def route_keys
+        ::NestedRouteDrawPortal::Engine.routes.resource_route_config_lookup.keys
+      end
+
+      def nested_keys
+        route_keys.select { |key| key.include?("/") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Every `has_many` and `has_one` whose child is a registered resource gets a nested route, whether or not anyone wanted one. Measured against the dummy app's org portal: **37 nested registrations across 8 parents**, most of which nothing links to.

`register_resource` now takes the list:

```ruby
register_resource ::Company, associations: %i[properties company_profile]
```

`associations: []` draws none.

## The mode

Naming none keeps today's behaviour, so nothing changes for an existing app. The config inverts what silence means:

```ruby
# config/initializers/plutonium.rb
Plutonium.configure do |config|
  config.nested_association_routes = :declared   # default: :detected
end
```

`:declared` gives a resource that names none no nested routes at all. `associations:` behaves the same in either mode, and top-level routes are untouched by both.

Opt-in, with no `load_defaults` wiring. Flipping this default in a version bump would delete every nested route in an app that never opted in.

## Two mistakes now fail the boot

The point of naming associations is to stop guessing which routes exist, so a typo that draws one route fewer would defeat it.

```
Blogging::Post is registered with `associations: [:commets]`, but :commets is not a
routable association on it. Available: :comments, :noninverse_comments, … .
Nested routes are drawn for has_many and has_one only.
```

```
Blogging::Post declares `associations: [:comments]`, but Comment is not registered in
this portal, so there is no route to nest under it. Add `register_resource Comment`
alongside it, or drop :comments from the list.
```

The second case was silently skipped before. That is right for a detected list and wrong for a declared one.

## Why a config and not `permitted_associations`

The obvious question is why routes don't just follow the policy's `permitted_associations`. They can't, and it isn't close:

* A policy instance needs a user. `Blogging::PostPolicy.new(Blogging::Post, user: nil)` raises `ActionPolicy::AuthorizationContextMissing`, and `permitted_associations` is designed to branch on `user` and `record`. A route table is global; there is no user to answer for at draw time.
* Policy files are not watched by the routes reloader (9 watched files, all `config/routes.rb`), so editing one would not redraw anything. Add an association, get a 404, and the cause is two files and one reload away.
* Measured on the dummy's org portal, following `permitted_associations` would drop 20 of 34 nested routes, including every route under the STI subtypes (`Blogging::Article`, `Blogging::Tutorial`), whose policies carry `%i[]` while `Blogging::PostPolicy` permits four.

## Known interaction

`permitted_associations` renders a show-page panel that links to the nested route (`display/resource.rb`, `resource_url_for(reflection.klass, parent: object, association: name)`). An association permitted there and omitted here leaves that panel pointing at a route that does not exist. The two lists have to agree, and that is stated in all four docs touched here.

## Tests

12, in a new `test/plutonium/routing/declared_nested_associations_test.rb`: both modes, `has_one` coverage, the empty list, top-level routes staying put, both boot failures, and the config setter rejecting a typo.

They draw a throwaway portal engine rather than redrawing one of the dummy app's own. Redrawing a real portal means restoring every engine from its routes file after each test, which cost 10s for this file against 0.4s this way.

## Verification

| version | tests | assertions | result |
| --- | --- | --- | --- |
| rails-8.1 | 3166 | 8205 | 0 failures, 0 errors |
| rails-8.0 | 3166 | 8205 | 0 failures, 0 errors |
| rails-7 | 3166 | 8149 | 0 failures, 0 errors |

`standardrb` clean on every changed file. `yarn docs:build` passes.
