### PR TITLE
docs(blog): publish the introduction post

### DIFF
--- a/docs/blog/introducing-plutonium.md
+++ b/docs/blog/introducing-plutonium.md
@@ -1,11 +1,10 @@
 ---
 title: "Introducing Plutonium: Rails conventions, past CRUD"
 titleTemplate: "Plutonium Blog"
-date: 2026-08-24
+date: 2026-08-22
 description: Rails made a bargain. Follow the conventions and the framework carries you. Plutonium makes the same bargain about the layer Rails deliberately left alone.
 author: Stefan Froelich
 tags: [announcement, rails, architecture]
-draft: true
 ---
 
 # Introducing Plutonium: Rails conventions, past CRUD


### PR DESCRIPTION
Enables `docs/blog/introducing-plutonium.md`. Two frontmatter lines, no prose changes.

```diff
-date: 2026-08-24
+date: 2026-08-22
-draft: true
```

## Why the date moved

Dropping `draft: true` on its own would not have published anything. Both `docs/.vitepress/theme/blog.data.ts:22` and `docs/.vitepress/config.ts:24` apply the cutoff `+new Date(date) <= Date.now()` at **build** time, and `.github/workflows/deploy_docs.yml` only runs on push to `master` or manual dispatch — there is no cron. A post dated the 24th would have stayed invisible until someone happened to push after that date.

Moving it to today means it goes live with this merge. If the Monday date was deliberate, revert that line and fire the deploy workflow manually on the 24th instead.

## Verified

`yarn docs:build` passes, no dead links. Against the built output:

- The feed carries exactly one `<item>`, the intro post. The other 10 drafts stay off both the index and the feed.
- This is the first non-draft post, so it flips `hasPublishedPost` and turns on the Blog nav entry plus the `rel="alternate"` RSS advert in `<head>`.

Per `CLAUDE.md` ("never publish a snippet you have not checked against this codebase"), each code sample in the post was checked against source: `scope_to_entity` (`lib/plutonium/engine.rb:15`), `associated_with_<entity>` custom scopes (`lib/plutonium/resource/record/associated_with.rb:18`), `as: :badge` with `colors:` (`lib/plutonium/ui/display/components/badge.rb:12`), `as: :phlexi_render` with `with:` (`lib/plutonium/ui/display/components/phlexi_render.rb`), `render_after_content` (`lib/plutonium/ui/page/base.rb:121`), `redirect_url_after_submit`, `current_definition.show_page_class`, `position_on`, the `class ShowPage < ShowPage` idiom, and both internal links. All correct.

## Known imprecision, left as-is

Line 54 gives the `associated_with` resolution order as `belongs_to` → `has_one` → reverse `has_many`. The code checks a custom `associated_with_<entity>` scope **before** any association (`associated_with.rb:19`), and among associations takes the first declaration whose class matches rather than preferring `belongs_to` by macro. The post covers the custom-scope route later as the escape hatch, and `.claude/skills/plutonium-tenancy/SKILL.md:81` states the same order, so the post is consistent with the shipped docs. Correcting both files is a reasonable follow-up but is out of scope here.

## Note

`yarn install` was needed to get `vitepress`; its postinstall rebuilt `app/assets/`. Both that and `yarn.lock` were restored, so the diff is the one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJuW1mgrdHrJhNLyLmemAM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJuW1mgrdHrJhNLyLmemAM)_