### PR TITLE
docs(reference): add the four unreachable pages to the landing rail

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,9 +12,11 @@ aside: false
   :rail="[
     { group: 'App', items: [
       { name: 'Overview', link: '/plutonium-core/reference/app/' },
+      { name: 'Configuration', link: '/plutonium-core/reference/configuration' },
       { name: 'Packages', link: '/plutonium-core/reference/app/packages' },
       { name: 'Portals', link: '/plutonium-core/reference/app/portals' },
       { name: 'Generators', link: '/plutonium-core/reference/app/generators' },
+      { name: 'Lite (SQLite) generators', link: '/plutonium-core/reference/generators/lite' },
     ]},
     { group: 'Resource', items: [
       { name: 'Overview', link: '/plutonium-core/reference/resource/' },
@@ -23,12 +25,14 @@ aside: false
       { name: 'Query', link: '/plutonium-core/reference/resource/query' },
       { name: 'Actions', link: '/plutonium-core/reference/resource/actions' },
       { name: 'Positioning', link: '/plutonium-core/reference/resource/positioning' },
+      { name: 'CSV Export', link: '/plutonium-core/reference/resource/export' },
     ]},
     { group: 'Behavior', items: [
       { name: 'Overview', link: '/plutonium-core/reference/behavior/' },
       { name: 'Controllers', link: '/plutonium-core/reference/behavior/controllers' },
       { name: 'Policies', link: '/plutonium-core/reference/behavior/policies' },
       { name: 'Interactions', link: '/plutonium-core/reference/behavior/interactions' },
+      { name: 'Async interactions', link: '/plutonium-core/reference/behavior/async-interactions' },
     ]},
     { group: 'UI', items: [
       { name: 'Overview', link: '/plutonium-core/reference/ui/' },


### PR DESCRIPTION
Follow-up to #109, which merged without this commit. Four lines.

## The problem

`/reference/` sets `sidebar: false`, so its `SectionLanding` rail is the **only** navigation on that page. Four pages were in the VitePress sidebar but absent from the rail, which made them unreachable from the reference landing page — you had to already be on some other reference page for the sidebar to appear and show them.

| Page | Path |
|---|---|
| Configuration | `/reference/configuration` |
| Lite (SQLite) generators | `/reference/generators/lite` |
| CSV Export | `/reference/resource/export` |
| Async interactions | `/reference/behavior/async-interactions` |

## Placement

Configuration and the lite generators join **App**, since both are application-level setup sitting next to Packages/Portals/Generators. CSV Export follows Positioning under **Resource**, and async interactions follow Interactions under **Behavior**. Both match the sidebar's own ordering.

## Verification

The rail and the sidebar now agree in both directions — every `/reference/*` entry in one appears in the other, checked by parsing `config.ts` and `index.md`:

```
missing from rail: none
rail entries not in sidebar: none
```

`yarn docs:build` passes. In a real browser against the built site: all four links render on `/reference/`, all 45 rail links return 200, and clicking Configuration lands on `/reference/configuration` with the right `<h1>`.

## Note on the underlying cause

The sidebar lives in `docs/.vitepress/config.ts` and the rail is hand-maintained in `docs/reference/index.md`, so the two drift silently — this is the second gap of the same shape found this week (the first was `resource/index.md` missing Positioning and CSV Export). A build-time assertion that the two agree would catch the next one. Happy to add it if you want; deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJuW1mgrdHrJhNLyLmemAM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJuW1mgrdHrJhNLyLmemAM)_