### PR TITLE
fix(docs): stop the nav overflowing, and let crushed tables scroll

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -185,3 +185,37 @@ img.pu-zoomable { cursor: zoom-in; }
 }
 .pu-zoom-close:hover { background: var(--vp-c-bg-mute); transform: scale(1.05); }
 .pu-zoom-close:focus-visible { outline: 2px solid var(--vp-c-brand-1); outline-offset: 2px; }
+
+/* ===== Nav bar fits before it unfolds ===== */
+
+/* VitePress swaps the hamburger for the full nav menu at exactly 768px. This
+   site's nav is seven items wide (~673px), which together with the logo, search
+   and appearance toggle needs about 1000px — so from 768 to 999 the bar did not
+   fit and the PAGE scrolled horizontally, squeezing the content column and
+   everything in it. Keep the hamburger until the menu actually fits.
+
+   These declarations reproduce the state VitePress itself renders below 768px,
+   so the hamburger opens the same nav screen it always did.
+
+   `!important` is load-bearing: the theme's own rule is `.VPNavBarMenu[data-v-…]`,
+   a scoped selector that outranks a plain class whatever the source order. The
+   `data-v` hash is regenerated per VitePress build, so matching its specificity
+   by copying it would break on the next upgrade. */
+@media (min-width: 768px) and (max-width: 999px) {
+  .VPNavBarMenu { display: none !important; }
+  .VPNavBarHamburger { display: flex !important; }
+  .VPNavBarExtra { display: none !important; }
+  .VPNavScreen { display: block !important; }
+}
+
+/* ===== Tables scroll instead of crushing ===== */
+
+/* `.vp-doc table` is `display: block; overflow-x: auto`, so a table CAN scroll —
+   but only once its content is wider than the container. A table whose cells are
+   all prose has no unbreakable token to force that, so instead of scrolling it
+   wraps down to whatever it is given: on a phone that meant columns of 59-89px,
+   a few characters per line. Giving each cell a floor makes the table exceed the
+   container, which is what turns the existing overflow-x into an actual scroll. */
+@media (max-width: 640px) {
+  .vp-doc :is(th, td) { min-width: 7rem; }
+}


### PR DESCRIPTION
Chasing "some tables still don't scroll and squish" turned up two separate causes. Both fixed in `custom.css`.

## 1. The page scrolled sideways from 768px to 999px

Not a table bug. VitePress swaps the hamburger for the full nav menu at exactly **768px**, and this site's nav is seven items (~673px) which — with the logo, search and appearance toggle — needs about **1000px**. Across that whole band the bar didn't fit and the *page* scrolled horizontally, squeezing the content column and everything in it.

Measured on the built site:

```
w=767   docW=767    no overflow   (hamburger)
w=768   docW=1033   OVERFLOW      (full menu appears)
w=900   docW=1033   OVERFLOW
w=999   docW=999    OVERFLOW
w=1000  docW=1000   no overflow
```

Every one of the 68 pages carrying a table overflowed at 768 and at 900. This is almost certainly the "squish" — at tablet width the whole layout is shoved sideways.

The fix keeps the hamburger until the menu actually fits. The three declarations reproduce the state VitePress already renders below 768px, so the same nav screen opens, with all seven links (verified by clicking it at 900px).

Enabling the blog in #108 added ~54px to the nav and made this worse, but it did not cause it: with the Blog item hidden the page still overflows at 768 (979 > 768).

**`!important` is load-bearing.** The theme's own rule is `.VPNavBarMenu[data-v-dc692963]` — a scoped selector that outranks a plain class regardless of source order, and that hash is regenerated per VitePress build, so matching its specificity by copying it would break on the next upgrade.

## 2. Nine tables genuinely could not scroll on a phone

`.vp-doc table` is already `display: block; overflow-x: auto`, so a table scrolls once its content outgrows the container — **109 of 226 already do**, forced wide by long code tokens. But a table whose cells are all *prose* has nothing unbreakable in it, so rather than scrolling it wrapped down to whatever width it was given: columns of 59–89px, a few characters per line, and no scrollbar to escape to.

A `min-width: 7rem` floor per cell at ≤640px makes those tables exceed the container, which is what turns the existing `overflow-x` into an actual scroll.

I swept 6/7/8/10rem and the wrapper-plus-`max-content` approach across all 226 tables at three viewports. `max-content` was clearly wrong (it moves the overflow onto the page — 14 pages started scrolling horizontally); 8rem and above forced 30–43 extra tables to scroll for no gain. 7rem fixes every stuck table while adding only 4 newly-scrolling ones.

## Verification

Built site, four viewports, all 68 table-bearing pages:

| | before | after |
|---|---|---|
| Pages with horizontal page scroll @768 / @900 | 68 / 68 | **0 / 0** |
| Tables stuck and crushed @412 | 9 | **0** |
| Narrowest cell @412 | 59px | **112px** |
| Tables scrolling @412 | 109 | 113 |
| @1280 geometry | — | unchanged |

## Deliberately not touched

19 tables still have a sub-90px cell at 1280px and don't scroll. I checked each one: they're `Key / ↑ / ↓`, `Default / nil`, and `✓` columns. Narrow is the correct answer for them — my initial `<90px` heuristic was flagging good layout, so I dropped that metric rather than "fixing" it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJuW1mgrdHrJhNLyLmemAM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJuW1mgrdHrJhNLyLmemAM)_