### PR TITLE
feat(doctor): add pu:core:doctor for mistakes that fail silently

### DIFF
--- a/.claude/skills/plutonium-behavior/SKILL.md
+++ b/.claude/skills/plutonium-behavior/SKILL.md
@@ -46,6 +46,8 @@ Then resolve the specifics:
 4. **`has_cents`** ⇒ permit `:price`, never `:price_cents`.
 5. **New vs editing** — never re-scaffold a controller/policy/interaction that's been customized.
 
+**Check yourself with `bin/rails g pu:core:doctor`** after editing a policy or a definition's actions. It reports exactly rules 1 and 2 above — an action with no policy predicate (`missing_policy_rule`), a `condition:` doing the user check the policy doesn't (`condition_as_authorization`), and a policy that never declares `permitted_attributes_for_create` / `_read` (`autodetected_permitted_attributes`, which raises in production and only logs in development). See [[plutonium]] › Checking your work.
+
 **Never ship a guessed role method, column, enum value, or association as applied code.** `user.finance?`, `record.status_approved?`, `expense.submitted_by` either exist in the app or they don't — confirm them before writing, don't assume. Fall back to `AskUserQuestion` only for genuine product choices (what the rule *should* be), never for facts you can read.
 
 ## ✅ Before you edit: verify the ground truth (CHECK — read it, don't ask for it)

--- a/.claude/skills/plutonium/SKILL.md
+++ b/.claude/skills/plutonium/SKILL.md
@@ -169,7 +169,25 @@ Every Plutonium generator is discoverable via `rails g pu:<tab>`. Always pass `-
 | `pu:eject:shell` | Eject topbar/sidebar partials | `plutonium-ui` |
 | `pu:test:install` | Install `Plutonium::Testing` scaffolding | `plutonium-testing` |
 | `pu:test:scaffold NAME --portals=...` | Scaffold integration tests | `plutonium-testing` |
+| `pu:core:doctor` | Check the app for mistakes that fail silently | (this skill) |
 | `pu:skills:sync` | Sync Plutonium Claude skills into the project | (this skill) |
+
+## Checking your work — `pu:core:doctor`
+
+```bash
+bin/rails g pu:core:doctor            # --strict to fail on warnings too, for CI
+```
+
+Writes nothing. Boots the app, walks every portal's resources, and reports the mistakes Plutonium cannot raise on — the ones that are legal, run, and quietly do nothing:
+
+| Check | What it catches |
+|---|---|
+| `missing_policy_rule` (error) | An action with no `<action>?` on the policy. ActionPolicy answers `false` for a rule that doesn't exist, so the button silently never renders. |
+| `autodetected_permitted_attributes` (error) | A policy that never declares `permitted_attributes_for_create` / `_read`. Logs a warning in development, **raises in production**. |
+| `condition_as_authorization` (warning) | A `condition:` doing the user check while the policy predicate doesn't. Hides the button; the route stays live. |
+| `redundant_field_declaration` (warning) | A `field` / `display` / `column` carrying no options and no block. Dead code, per §1 above. |
+
+**Run it after generating or editing definitions and policies.** These are the exact rules this skill teaches, and the doctor is the only thing that checks whether you followed them. A finding you believe is wrong goes in `.plutonium-doctor.yml` (`disable:` a check, or `ignore:` the key the report prints) — don't leave it unexplained.
 
 ## Unattended execution
 
@@ -192,4 +210,5 @@ Meta-generators (`pu:saas:setup`) propagate flags to the generators they chain. 
 3. **Migrate** — `rails db:prepare`.
 4. **Connect** — `rails g pu:res:conn Model --dest=portal_name`.
 5. **Customize** — edit definition / policy as needed.
-6. **Verify** — hit the route in the browser.
+6. **Check** — `rails g pu:core:doctor`.
+7. **Verify** — hit the route in the browser.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -192,6 +192,7 @@ export default defineConfig(withMermaid({
             { text: "Portals", link: "/reference/app/portals" },
             { text: "Generators", link: "/reference/app/generators" },
             { text: "Lite (SQLite) Generators", link: "/reference/generators/lite" },
+            { text: "Doctor", link: "/reference/app/doctor" },
           ]
         },
         {

--- a/docs/reference/app/doctor.md
+++ b/docs/reference/app/doctor.md
@@ -1,0 +1,124 @@
+# Doctor
+
+`pu:core:doctor` checks a booted application for Plutonium mistakes that fail silently.
+
+```bash
+bin/rails g pu:core:doctor
+bin/rails g pu:core:doctor --strict           # warnings fail too
+bin/rails g pu:core:doctor --portal=admin_portal
+```
+
+It writes nothing. It boots the app, walks every portal's registered resources, and prints what it found. With `--strict` it exits non-zero when anything at all is reported; without it, only errors fail the run.
+
+## What it is for
+
+Plutonium raises wherever it can. Defining `relation_scope` as an instance method raises the moment the method is defined. A `columns:` key copied from a form layout into a display layout raises. Registering a model that never included `Plutonium::Resource::Record` raises.
+
+The doctor covers what is left: code that is legal, runs, and quietly does nothing. That is the rule for every check here, and for any check added later. **If a mistake can be made to raise, it belongs in the framework, not in the doctor.** A raise reaches every application the moment the mistake is written. A check reaches only the people who run it.
+
+## Checks
+
+### `missing_policy_rule` (error)
+
+An action with no `<action>?` on the policy.
+
+```ruby
+# PostDefinition
+action :publish, interaction: PublishPost, record_action: true
+
+# PostPolicy — nothing about :publish
+```
+
+`Action::Base#permitted_by?` asks `policy.allowed_to?(:publish?)`, and ActionPolicy answers `false` for a rule that does not exist rather than raising. The button never renders, and nothing says why.
+
+```ruby
+class PostPolicy < Plutonium::Resource::Policy
+  def publish? = update?
+end
+```
+
+Hidden actions are exempt. `hidden: true` means the action renders nowhere, so there is no missing button to explain, and a kanban column's `enter_interaction` is predicate-less by design: `kanban_move?` authorizes the drop.
+
+### `autodetected_permitted_attributes` (error)
+
+A policy that never says which attributes it permits.
+
+```ruby
+class PostPolicy < Plutonium::Resource::Policy
+  def create? = true
+  def read? = true
+  # no permitted_attributes_for_create / _read
+end
+```
+
+`autodetect_permitted_fields` permits every field on the model, and outside development it raises instead. In development it only writes to the log, so this works on the machine it was written on and 500s on deploy.
+
+```ruby
+def permitted_attributes_for_create = %i[title body published_at]
+def permitted_attributes_for_read = %i[title body published_at author]
+```
+
+An entry point the application answers for itself is not reported, even when the base method underneath it is still Plutonium's. A policy defining `permitted_attributes_for_index` and `permitted_attributes_for_show` never reaches `permitted_attributes_for_read`.
+
+### `condition_as_authorization` (warning)
+
+An action whose only user check is its `condition:`.
+
+```ruby
+action :publish,
+  interaction: PublishPost,
+  record_action: true,
+  condition: -> { current_user.admin? }   # hides the button
+
+def publish? = update?                     # allows anyone who can update
+```
+
+`condition:` decides whether a button renders. The policy decides whether the action may run. The route stays live, so a direct POST reaches the interaction for anyone `publish?` allows.
+
+Both halves have to hold before this reports: the condition reads like an authorization decision, and the policy predicate does not. A predicate that delegates (`def publish? = update?`) counts as not deciding, because it answers a different question than the condition asks. The report quotes the condition so you can judge it at a glance.
+
+Keep the `condition:` if it is also doing presentation work. Move the user check into the policy either way.
+
+### `redundant_field_declaration` (warning)
+
+A `field`, `display`, or `column` declaration carrying no options and no block.
+
+```ruby
+field :title      # dead: this is exactly what was already inferred
+```
+
+Plutonium renders every permitted attribute from the model already. The surfaces only look declarations up by name while iterating a list that comes from the policy, so a declaration with no options is read and discarded. Declare one when you are overriding something: `as: :markdown`, a `hint:`, a `wrapper:`, a `condition:`, or a block.
+
+To make a field appear or disappear, change `permitted_attributes_for_*` on the policy. A declaration in the definition has no say in it.
+
+`input` is never checked. Its keys are a source list rather than a lookup: nested resource fields, structured inputs and wizard steps all take their field set from `defined_inputs.keys`, so a bare `input :title` is load-bearing there.
+
+## Suppressing a finding
+
+Every check is a judgement about intent, and some of those judgements will be wrong about a particular line. Put a `.plutonium-doctor.yml` in the application root:
+
+```yaml
+# Turn a check off entirely.
+disable:
+  - redundant_field_declaration
+
+# Silence individual findings, by the key the report prints under each one.
+ignore:
+  - missing_policy_rule:Blogging::Post#publish
+```
+
+The report prints each finding's key so the line can be copied straight out of the output.
+
+## Portals
+
+Definitions and policies are resolved the way a request resolves them: portal namespace first, top level as the fallback. A portal that overrides `PostDefinition` with `AdminPortal::PostDefinition` is checked against the class that actually serves the request.
+
+One mistake reached through several portals is reported once, with the portals named. A finding that only exists in one portal, because that portal overrode the definition or the policy, is reported against that portal alone.
+
+## In CI
+
+```yaml
+- run: bin/rails g pu:core:doctor --strict
+```
+
+Start without `--strict` if an existing app has warnings to work through. Errors fail the run either way.

--- a/docs/reference/app/generators.md
+++ b/docs/reference/app/generators.md
@@ -31,6 +31,7 @@ Plutonium's `pu:*` CLI generators. Discoverable via `rails g pu:<tab>`. Always p
 | [`pu:eject:shell`](#pu-eject-shell) | Eject topbar/sidebar partials |
 | [`pu:test:install`](#pu-test-install) | Install `Plutonium::Testing` scaffolding |
 | [`pu:test:scaffold`](#pu-test-scaffold) | Scaffold integration tests per (resource × portal) |
+| [`pu:core:doctor`](#pu-core-doctor) | Check the app for mistakes that fail silently |
 | [`pu:core:update`](#pu-core-update) | Update plutonium gem + npm package |
 | [`pu:skills:sync`](#pu-skills-sync) | Sync Plutonium Claude skills into the project |
 
@@ -351,6 +352,18 @@ rails g pu:core:assets
 ```
 
 See [UI › Assets](/reference/ui/assets) for what gets configured.
+
+### `pu:core:doctor`
+
+Check the application for Plutonium mistakes that fail silently: an action with no policy predicate, a policy that never declares its permitted attributes, a `condition:` standing in for authorization, a field declaration that repeats what was already inferred.
+
+```bash
+rails g pu:core:doctor
+rails g pu:core:doctor --strict           # warnings fail too, for CI
+rails g pu:core:doctor --portal=admin_portal
+```
+
+Writes nothing. Exits non-zero on errors, or on anything at all with `--strict`. See [App › Doctor](./doctor) for each check and for `.plutonium-doctor.yml`.
 
 ### `pu:core:update`
 

--- a/lib/generators/pu/core/doctor/doctor_generator.rb
+++ b/lib/generators/pu/core/doctor/doctor_generator.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/plutonium_generators"
+
+module Pu
+  module Core
+    # Inspects a booted application for the mistakes Plutonium cannot raise on.
+    #
+    #   bin/rails g pu:core:doctor
+    #   bin/rails g pu:core:doctor --strict          # warnings fail too (CI)
+    #   bin/rails g pu:core:doctor --portal=admin
+    #
+    # A generator rather than a rake task only for consistency: everything else
+    # a Plutonium developer runs is `bin/rails g pu:…`, and a diagnostic hiding
+    # under a different verb is a diagnostic nobody finds. It writes nothing.
+    class DoctorGenerator < Rails::Generators::Base
+      include PlutoniumGenerators::Generator
+
+      desc "Check this application for Plutonium mistakes that fail silently"
+
+      class_option :portal, type: :string, desc: "Only inspect this portal"
+      class_option :strict, type: :boolean, default: false,
+        desc: "Exit non-zero on warnings as well as errors"
+
+      # Rails generators default this to false, which would print the failure
+      # and still exit 0 — fine for a generator that has written most of its
+      # files, useless for a checker whose entire job in CI is the exit code.
+      def self.exit_on_failure? = true
+
+      def start
+        load_application
+
+        report = Plutonium::Doctor.run(only: options[:portal])
+        Plutonium::Doctor::Reporter.new(report, io: $stdout).call
+
+        return if report.pass?(strict: options[:strict])
+
+        # Thor::Error is how a generator exits non-zero without a backtrace,
+        # which is what a CI step wants from a checker.
+        raise Thor::Error, failure_message(report)
+      end
+
+      private
+
+      def load_application
+        Rails.application.eager_load!
+        Rails.application.reload_routes!
+      end
+
+      def failure_message(report)
+        if options[:strict]
+          "plutonium doctor: #{report.errors.size} error(s), #{report.warnings.size} warning(s)"
+        else
+          "plutonium doctor: #{report.errors.size} error(s)"
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor.rb
+++ b/lib/plutonium/doctor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Plutonium
+  # Inspection of a booted Plutonium application, for the class of mistake the
+  # framework cannot raise on: code that is legal, runs, and quietly does
+  # nothing.
+  #
+  # Plutonium already fails loudly wherever it can. `Policy.method_added`
+  # catches an instance-method `relation_scope` the moment it is defined,
+  # `display_layout` raises on a `columns:` copied from a form layout, the
+  # resource register refuses a model that never included Record. What is left
+  # over is the residue those guards deliberately do not cover: a policy
+  # predicate nobody wrote (the action is simply never offered), a `condition:`
+  # standing in for authorization (the button hides, the POST still lands), a
+  # field redeclared exactly as it was already inferred.
+  #
+  # That is the selection rule for everything in here, and the rule for anything
+  # added later: **if a mistake can be made to raise, it belongs in the
+  # framework, not in the doctor.** A raise reaches every application at the
+  # moment the mistake is made. A check reaches only the people who run it. The
+  # doctor is for what is left when raising would be wrong — because the shape
+  # is legal in another context, or because the code is merely untidy rather
+  # than broken.
+  module Doctor
+    class << self
+      # @return [Plutonium::Doctor::Report]
+      def run(**) = Runner.new(**).call
+    end
+  end
+end

--- a/lib/plutonium/doctor/check.rb
+++ b/lib/plutonium/doctor/check.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # Base class for a doctor check.
+    #
+    # A check is handed one {Target} — a resource as one portal resolves it —
+    # and answers with zero or more {Finding}s. It never prints, never decides
+    # whether it is enabled, and never looks at other targets; the {Runner}
+    # owns all three so that a check stays a pure function of its target and
+    # can be unit-tested by constructing a target directly.
+    #
+    # Subclasses declare a severity and implement {#call}:
+    #
+    #   class MyCheck < Check
+    #     def self.severity = :error
+    #
+    #     def call
+    #       return [] if fine?
+    #       [finding(subject: "…", message: "…", details: "…")]
+    #     end
+    #   end
+    class Check
+      class << self
+        # The name used in reports, in `.plutonium-doctor.yml`, and as the
+        # first half of a suppression key. Derived so the two can never drift.
+        # @return [Symbol]
+        def check_name = name.demodulize.underscore.to_sym
+
+        # @return [Symbol] :error or :warning
+        def severity = :warning
+      end
+
+      # @param target [Target]
+      def initialize(target)
+        @target = target
+      end
+
+      attr_reader :target
+
+      # @return [Array<Finding>]
+      def call
+        raise NotImplementedError, "#{self.class} must implement #call"
+      end
+
+      private
+
+      def finding(subject:, message:, details: nil)
+        Finding.new(
+          check: self.class.check_name,
+          severity: self.class.severity,
+          subject: subject,
+          message: message,
+          details: details,
+          scope: target.portal.name
+        )
+      end
+
+      # Whether a method on the target's policy is the application's or one of
+      # Plutonium's own defaults.
+      #
+      # Several checks turn on this distinction: an app that never wrote the
+      # method has not made a decision, it has inherited one, and inherited
+      # defaults are exactly where the silent failures live.
+      def app_defined_policy_method?(name)
+        return false unless target.policy_class.method_defined?(name) ||
+          target.policy_class.private_method_defined?(name)
+
+        owner = target.policy_class.instance_method(name).owner
+        !owner.name.to_s.start_with?("Plutonium::", "ActionPolicy::")
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/checks/autodetected_permitted_attributes.rb
+++ b/lib/plutonium/doctor/checks/autodetected_permitted_attributes.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    module Checks
+      # A policy that never says which attributes it permits.
+      #
+      # `Policy#autodetect_permitted_fields` hands back every field on the model
+      # and, outside development, raises rather than doing so — the comment in
+      # `Plutonium::Resource::Policy` is blunt about why ("Auto-detected resource
+      # fields result in security holes"). In development it only writes a
+      # warning to the log, which is exactly where a warning gets missed. So the
+      # app works on the machine it was written on and 500s the first time it is
+      # deployed.
+      #
+      # This is not the framework failing to raise; it raises hard. It is the
+      # raise landing in the wrong environment to be useful, which is what makes
+      # it worth finding early.
+      #
+      # An entry point the application overrode is not reported, even when the
+      # base method underneath it is still Plutonium's: `permitted_attributes_for_edit`
+      # answered by the app is answered, and never reaches the autodetecting
+      # `permitted_attributes_for_create` below it.
+      class AutodetectedPermittedAttributes < Check
+        def self.severity = :error
+
+        # The two methods that actually call `autodetect_permitted_fields`.
+        BASES = %i[permitted_attributes_for_create permitted_attributes_for_read].freeze
+
+        # How Plutonium's own defaults delegate, from
+        # `Plutonium::Resource::Policy`. Hardcoded because the delegation lives
+        # in method bodies and cannot be read off the class — and locked to the
+        # real thing by AutodetectedPermittedAttributesTest, which probes the
+        # base policy and fails if this map ever drifts from it.
+        DELEGATIONS = {
+          permitted_attributes_for_new: :permitted_attributes_for_create,
+          permitted_attributes_for_edit: :permitted_attributes_for_update,
+          permitted_attributes_for_update: :permitted_attributes_for_create,
+          permitted_attributes_for_index: :permitted_attributes_for_read,
+          permitted_attributes_for_show: :permitted_attributes_for_read,
+          permitted_attributes_for_export: :permitted_attributes_for_index
+        }.freeze
+
+        # What a controller asks for, by action.
+        ENTRY_POINTS = %i[
+          permitted_attributes_for_index
+          permitted_attributes_for_show
+          permitted_attributes_for_new
+          permitted_attributes_for_edit
+          permitted_attributes_for_create
+          permitted_attributes_for_update
+          permitted_attributes_for_export
+        ].freeze
+
+        def call
+          reached = Hash.new { |h, k| h[k] = [] }
+
+          ENTRY_POINTS.each do |entry|
+            base = autodetecting_base_for(entry)
+            reached[base] << entry if base
+          end
+
+          reached.map do |base, entries|
+            finding(
+              subject: "#{target.resource_class}##{base}",
+              message: "#{target.policy_class} does not define `#{base}` — it will raise outside development",
+              details: <<~TEXT
+                Reached by: #{entries.join(", ")}
+
+                Without an override, `#{base}` calls `autodetect_permitted_fields`, which
+                permits every field on #{target.resource_class} and raises outside development.
+                In development it only logs a warning, so this passes locally and fails on deploy.
+
+                Declare the attributes on #{target.policy_class}:
+
+                    def #{base}
+                      %i[#{sample_attributes.join(" ")}]
+                    end
+
+                List columns only. A `*_attributes` key for a nested association does not
+                belong here — permit those through the nested resource's own policy.
+              TEXT
+            )
+          end
+        end
+
+        private
+
+        # Follows Plutonium's delegation from an entry point down to the method
+        # that would autodetect, stopping the moment the application has
+        # answered for itself.
+        #
+        # @return [Symbol, nil] the autodetecting base, or nil if nothing autodetects
+        def autodetecting_base_for(entry)
+          seen = []
+          current = entry
+
+          while current
+            return nil if app_defined_policy_method?(current)
+            return current if BASES.include?(current)
+
+            # Defensive only against a future cycle in DELEGATIONS; the map as
+            # written terminates.
+            return nil if seen.include?(current)
+            seen << current
+
+            current = DELEGATIONS[current]
+          end
+
+          nil
+        end
+
+        # A few real column names, so the suggested override is copy-pasteable
+        # rather than a placeholder.
+        def sample_attributes
+          names = target.resource_class.resource_field_names
+          names -= [target.resource_class.primary_key.to_sym, :created_at, :updated_at]
+          names.first(4).presence || %i[name]
+        rescue
+          %i[name]
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/checks/condition_as_authorization.rb
+++ b/lib/plutonium/doctor/checks/condition_as_authorization.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    module Checks
+      # An action whose only user check is its `condition:`.
+      #
+      # `condition:` decides whether a button renders. The policy decides
+      # whether the action may run. `Action::Base#condition_met?` says so in as
+      # many words — "NOT an authorization boundary; a hidden action still has a
+      # live route" — but the two read alike at the call site, and putting the
+      # role check in the condition is a natural mistake to make. The button
+      # disappears, the author sees the behaviour they asked for, and the route
+      # goes on accepting a direct POST from anyone the policy allows.
+      #
+      # Nothing can raise here: a `condition:` that mentions the current user is
+      # perfectly legal, and often deliberate — a condition may narrow an
+      # already-authorized action for presentation. Only the pairing is
+      # suspicious, so both halves have to hold:
+      #
+      #   1. the condition reads like an authorization decision, and
+      #   2. the policy predicate does not.
+      #
+      # A predicate that delegates (`def publish? = update?`) counts as not
+      # deciding: the app wrote it, but it answers a different question than the
+      # condition does, so the condition is still the only place the user is
+      # being checked.
+      #
+      # A predicate that does not exist at all belongs to {MissingPolicyRule};
+      # reporting it here too would say one thing twice.
+      class ConditionAsAuthorization < Check
+        def self.severity = :warning
+
+        # Tokens that make a snippet read as an authorization decision rather
+        # than a presentation one. Applied to both halves, which is what keeps
+        # the check symmetric: whatever counts as "checking the user" in a
+        # condition counts as "checking the user" in a policy too.
+        #
+        # A heuristic, and only ever decides whether to SPEAK — never what is
+        # true. The report quotes the source so the reader judges it at a glance.
+        AUTHORIZATION_TOKENS = /\b(?:current_user|user|admin|role|owner|permission|allowed_to\?|can_|policy)\b/
+
+        # How far past a declaration to read when quoting it. Long enough for a
+        # realistic lambda or method body, short enough that a runaway read
+        # cannot happen.
+        SOURCE_WINDOW = 5
+
+        def call
+          target.definition.defined_actions.filter_map do |name, action|
+            next if action.condition.nil?
+
+            predicate = :"#{name}?"
+            # Undefined entirely — MissingPolicyRule owns that finding.
+            next unless defined_predicate?(predicate)
+
+            condition = source_of(action.condition.source_location)
+            next unless condition&.match?(AUTHORIZATION_TOKENS)
+            next if policy_checks_the_user?(predicate)
+
+            build_finding(name, predicate, condition)
+          end
+        end
+
+        private
+
+        def defined_predicate?(predicate)
+          target.policy_class.method_defined?(predicate) ||
+            target.policy_class.private_method_defined?(predicate)
+        end
+
+        # Whether the policy's own answer for this action looks at the user.
+        #
+        # A framework default never does — Plutonium's predicates delegate among
+        # themselves down to `create?`/`read?`, which an application overrides
+        # without reference to any particular action. Anything the application
+        # wrote is judged by the same token list as the condition.
+        def policy_checks_the_user?(predicate)
+          method = target.policy_class.instance_method(predicate)
+          return false if framework_owned?(method)
+
+          source = source_of(method.source_location)
+          # Unreadable source is treated as deciding, so an unquotable policy
+          # keeps the check quiet rather than guessing about it.
+          return true if source.nil?
+
+          source.match?(AUTHORIZATION_TOKENS)
+        end
+
+        def framework_owned?(method)
+          method.owner.name.to_s.start_with?("Plutonium::", "ActionPolicy::")
+        end
+
+        def build_finding(name, predicate, condition)
+          finding(
+            subject: "#{target.resource_class}##{name}",
+            message: "`#{name}` checks the user in `condition:`, but `#{predicate}` does not",
+            details: <<~TEXT
+              The condition reads as an authorization rule:
+
+              #{condition.strip.gsub(/^/, "    ")}
+
+              `condition:` only decides whether the button renders. The route stays live, so a
+              direct request runs the action for anyone `#{predicate}` allows. Move the rule
+              into #{target.policy_class}:
+
+                  def #{predicate}
+                    user.admin?   # whatever the condition was deciding
+                  end
+
+              Keep the `condition:` as well if it is also doing presentation work.
+            TEXT
+          )
+        end
+
+        # The source lines at a [file, line] pair, for quoting in the report.
+        #
+        # Best effort by construction: source built somewhere unreadable (an
+        # eval, a stripped deployment) yields nil, and the caller decides what
+        # silence means. Both callers here choose the quiet direction.
+        def source_of(location)
+          file, line = location
+          return unless file && line && File.readable?(file)
+
+          File.foreach(file).drop(line - 1).first(SOURCE_WINDOW).join
+        rescue SystemCallError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/checks/missing_policy_rule.rb
+++ b/lib/plutonium/doctor/checks/missing_policy_rule.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    module Checks
+      # An action whose policy predicate nobody defined.
+      #
+      # `Action::Base#permitted_by?` asks `policy.allowed_to?(:"#{name}?")`, and
+      # ActionPolicy answers `false` for a rule that does not exist rather than
+      # raising. So the button never renders, and nothing anywhere says why —
+      # the author sees a missing button and goes looking in the definition,
+      # which is the one file that is correct.
+      #
+      # For an interactive action this is also the difference between hidden and
+      # denied: the route is mounted either way, so a direct POST is refused by
+      # the same missing predicate that hid the button. That is the safe
+      # direction, which is precisely why nothing raises and why this check has
+      # to exist.
+      #
+      # Hidden actions are exempt, and not as a concession. `hidden: true` means
+      # the action renders on no surface at all, so there is no button whose
+      # absence could be mistaken for a styling problem — the failure this check
+      # describes cannot happen. It is also how the framework builds a kanban
+      # column's `enter_interaction`: deliberately predicate-less, because the
+      # drop that reaches it is authorized by `kanban_move?` instead. A check
+      # that flagged those would be wrong about the framework's own output on
+      # every board.
+      class MissingPolicyRule < Check
+        def self.severity = :error
+
+        def call
+          target.definition.defined_actions.filter_map do |name, action|
+            next if action.hidden?
+
+            predicate = :"#{name}?"
+            next if target.policy_class.method_defined?(predicate) ||
+              target.policy_class.private_method_defined?(predicate)
+
+            finding(
+              subject: "#{target.resource_class}##{name}",
+              message: "#{kind(action)} `#{name}` has no `#{predicate}` in #{target.policy_class}",
+              details: <<~TEXT
+                ActionPolicy answers false for a rule that is not defined, so this action
+                never renders and the omission is silent.#{" "}
+
+                Add the predicate to #{target.policy_class}:
+
+                    def #{predicate}
+                      update?   # or whatever authorizes this action
+                    end
+              TEXT
+            )
+          end
+        end
+
+        private
+
+        def kind(action)
+          if action.bulk_action? then "Bulk action"
+          elsif action.record_action? || action.collection_record_action? then "Record action"
+          elsif action.resource_action? then "Resource action"
+          else "Action"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/checks/redundant_field_declaration.rb
+++ b/lib/plutonium/doctor/checks/redundant_field_declaration.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    module Checks
+      # A field declaration that says nothing the framework had not already
+      # worked out.
+      #
+      # Plutonium reads the model and renders every permitted attribute
+      # already — type, label, widget, formatter, column. `field :title` with no
+      # options and no block adds nothing: the surfaces only ever look
+      # declarations UP by name (`defined_fields[name]`) while iterating a list
+      # that comes from the policy, so an entry carrying no options is read and
+      # discarded. It is dead on the day it is written, and it goes stale the
+      # day the column changes type.
+      #
+      # `input` is deliberately not checked. Its keys are a source list, not
+      # just a lookup: nested resource fields, structured inputs and wizard
+      # steps all take their field set from `defined_inputs.keys`, so a bare
+      # `input :title` is load-bearing in those contexts and only sometimes
+      # redundant. Warning on it would train people to ignore the doctor.
+      class RedundantFieldDeclaration < Check
+        def self.severity = :warning
+
+        # The declaration kinds whose entries are pure lookups, so that a
+        # bare declaration cannot be doing anything.
+        KINDS = %i[field display column].freeze
+
+        def call
+          KINDS.flat_map { |kind| findings_for(kind) }
+        end
+
+        private
+
+        def findings_for(kind)
+          declarations = target.definition.public_send(:"defined_#{kind.to_s.pluralize}")
+
+          declarations.filter_map do |name, data|
+            next unless bare?(data)
+
+            finding(
+              subject: "#{target.definition_class}##{kind}:#{name}",
+              message: "`#{kind} :#{name}` in #{target.definition_class} declares nothing and can be deleted",
+              details: <<~TEXT
+                Plutonium already renders :#{name} from the model — this line only repeats
+                what was inferred, and stops matching the moment the column changes.
+
+                Declare a #{kind} when you are overriding something: a different type
+                (`as: :markdown`), an option (`hint:`, `placeholder:`, `wrapper:`), a
+                `condition:`, or a block. Otherwise delete the line.
+
+                To make :#{name} appear or disappear, change `permitted_attributes_for_*`
+                on the policy — a declaration here has no say in that.
+              TEXT
+            )
+          end
+        end
+
+        # A declaration is bare when it carries neither options nor a block.
+        # The merged hash is built with `.compact`, so an option-less, block-less
+        # declaration arrives as `{options: {}}`.
+        def bare?(data)
+          data[:block].nil? && data[:options].blank?
+        end
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/config.rb
+++ b/lib/plutonium/doctor/config.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Plutonium
+  module Doctor
+    # `.plutonium-doctor.yml`, read from the application root.
+    #
+    # Suppression exists from the first release on purpose. Every check here is
+    # a judgement about intent, and some of those judgements will be wrong about
+    # a particular line — a condition that reads like a role check but is not, a
+    # redundant-looking declaration kept deliberately. A checker with no way to
+    # say "yes, I meant that" gets muted wholesale, and then it may as well not
+    # run at all.
+    #
+    #   # .plutonium-doctor.yml
+    #   disable:
+    #     - redundant_field_declaration
+    #   ignore:
+    #     - missing_policy_rule:Blogging::Post#publish
+    #
+    # `ignore` entries are the keys the report prints under each finding, so a
+    # line can be copied straight out of the output.
+    class Config
+      DEFAULT_FILENAME = ".plutonium-doctor.yml"
+
+      attr_reader :path, :disabled, :ignored
+
+      # @param root [Pathname, String, nil] application root; nil skips file loading
+      def self.load(root: default_root, filename: DEFAULT_FILENAME)
+        return new if root.nil?
+
+        path = Pathname.new(root).join(filename)
+        return new unless path.file?
+
+        data = YAML.safe_load_file(path) || {}
+        new(
+          path: path,
+          disabled: Array(data["disable"]).map(&:to_sym),
+          ignored: Array(data["ignore"]).map(&:to_s)
+        )
+      end
+
+      def self.default_root = defined?(Rails.root) ? Rails.root : nil
+
+      def initialize(path: nil, disabled: [], ignored: [])
+        @path = path
+        @disabled = disabled.to_set
+        @ignored = ignored.to_set
+      end
+
+      def disabled?(check_name) = disabled.include?(check_name.to_sym)
+
+      def ignored?(finding) = ignored.include?(finding.key)
+    end
+  end
+end

--- a/lib/plutonium/doctor/finding.rb
+++ b/lib/plutonium/doctor/finding.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # One thing worth telling the author about.
+    #
+    # `subject` is the finding's identity — "Blogging::Post#publish" — and
+    # deliberately carries no portal. The same definition is usually reached
+    # through several portals, and reporting one mistake three times because
+    # three portals mount the resource is noise. Duplicates fold together via
+    # {#merge_scope}, which keeps the portal list so the report can still say
+    # where it was seen.
+    #
+    # That identity is also the suppression key, printed verbatim in the report
+    # so a line can be pasted straight into `.plutonium-doctor.yml`.
+    class Finding
+      SEVERITIES = %i[error warning].freeze
+
+      attr_reader :check, :severity, :subject, :message, :details, :scopes
+
+      def initialize(check:, severity:, subject:, message:, details: nil, scope: nil)
+        unless SEVERITIES.include?(severity)
+          raise ArgumentError, "unknown severity #{severity.inspect}, expected one of #{SEVERITIES.inspect}"
+        end
+
+        @check = check.to_sym
+        @severity = severity
+        @subject = subject.to_s
+        @message = message
+        @details = details
+        @scopes = Array(scope).compact
+      end
+
+      # The suppression key, and the identity duplicates fold on.
+      # @return [String]
+      def key = "#{check}:#{subject}"
+
+      def error? = severity == :error
+
+      def warning? = severity == :warning
+
+      # Folds an identical finding reached through another portal into this one.
+      # @param other [Finding]
+      # @return [self]
+      def merge_scope(other)
+        @scopes |= other.scopes
+        self
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/portals.rb
+++ b/lib/plutonium/doctor/portals.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # The portals of a booted application, and what each registered.
+    #
+    # Traversal mirrors Pu::Core::TypespecGenerator: portal engines come from
+    # Rails::Engine.subclasses, resources from each engine's own register. Going
+    # portal by portal rather than straight down the register matters, because
+    # a portal can override both the definition and the policy for a resource —
+    # inspecting only the top-level pair would check classes that never serve a
+    # request.
+    class Portals
+      Portal = Struct.new(:name, :engine, :namespace, :resources)
+
+      # @param only [String, nil] restrict to one portal, by underscored name
+      def self.discover(only: nil) = new(only: only).call
+
+      def initialize(only: nil)
+        @only = only
+      end
+
+      def call
+        engines.filter_map do |engine|
+          name = engine.name.sub(/::Engine$/, "")
+          next if @only && name.underscore != @only.to_s.underscore
+
+          Portal.new(
+            name: name,
+            engine: engine,
+            namespace: engine.module_parent,
+            resources: resources_for(engine)
+          )
+        end
+      end
+
+      private
+
+      def engines
+        Rails::Engine.subclasses.select do |engine|
+          engine.name.present? &&
+            engine.included_modules.any? { |mod| mod.name&.include?("Plutonium::Portal") }
+        end
+      end
+
+      def resources_for(engine)
+        engine.resource_register.resources
+      rescue => e
+        # A register that cannot be read is a boot problem, not something the
+        # doctor should crash on halfway through a report.
+        Plutonium.logger&.warn { "[plutonium doctor] could not read register for #{engine}: #{e.message}" }
+        []
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/report.rb
+++ b/lib/plutonium/doctor/report.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # The result of a run: findings, plus enough context to say what was looked
+    # at. "No findings" and "nothing was inspected" print very differently, and
+    # conflating them is how a checker ends up quietly passing a CI job it never
+    # ran against anything.
+    class Report
+      attr_reader :findings, :portals_inspected, :resources_inspected, :checks_run, :config
+
+      def initialize(findings:, portals_inspected:, resources_inspected:, checks_run:, config: nil)
+        @findings = findings
+        @portals_inspected = portals_inspected
+        @resources_inspected = resources_inspected
+        @checks_run = checks_run
+        @config = config
+      end
+
+      def errors = findings.select(&:error?)
+
+      def warnings = findings.select(&:warning?)
+
+      def empty? = findings.empty?
+
+      def nothing_inspected? = resources_inspected.zero?
+
+      # Whether the run should be treated as a pass.
+      #
+      # @param strict [Boolean] when true, warnings fail too
+      def pass?(strict: false)
+        strict ? findings.empty? : errors.empty?
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/reporter.rb
+++ b/lib/plutonium/doctor/reporter.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # Renders a {Report} as text.
+    #
+    # Every finding prints its suppression key, because the alternative to an
+    # easy suppression is a muted checker. Errors come first, then warnings, and
+    # findings of the same check stay together so a systemic mistake reads as
+    # one problem rather than fourteen.
+    class Reporter
+      COLORS = {error: "\e[31m", warning: "\e[33m", dim: "\e[90m", bold: "\e[1m", reset: "\e[0m"}.freeze
+
+      def initialize(report, io: $stdout, color: io.respond_to?(:tty?) && io.tty?)
+        @report = report
+        @io = io
+        @color = color
+      end
+
+      def call
+        if @report.nothing_inspected?
+          @io.puts "No Plutonium resources found to inspect."
+          @io.puts dim("Portals are discovered from mounted engines; check that `register_resource` ran.")
+          return @report
+        end
+
+        %i[error warning].each do |severity|
+          grouped(severity).each { |check, findings| print_group(severity, check, findings) }
+        end
+
+        print_summary
+        @report
+      end
+
+      private
+
+      def grouped(severity)
+        @report.findings.select { |f| f.severity == severity }.group_by(&:check)
+      end
+
+      def print_group(severity, check, findings)
+        @io.puts
+        @io.puts "#{colorize(severity.to_s.upcase, severity)} #{bold(check.to_s)} #{dim("(#{findings.size})")}"
+
+        findings.each do |finding|
+          @io.puts
+          @io.puts "  #{finding.message}"
+          @io.puts dim("  in #{finding.scopes.join(", ")}") if finding.scopes.any?
+          @io.puts
+          finding.details.to_s.each_line { |line| @io.puts "    #{line.chomp}" }
+          @io.puts dim("    silence with:  #{finding.key}")
+        end
+      end
+
+      def print_summary
+        @io.puts
+        @io.puts "─" * 60
+        counts = [
+          count(@report.errors.size, "error"),
+          count(@report.warnings.size, "warning")
+        ].join(", ")
+
+        scope = "#{count(@report.resources_inspected, "resource")} across " \
+                "#{count(@report.portals_inspected, "portal")}"
+
+        @io.puts @report.empty? ? "No problems found in #{scope}." : "#{counts} in #{scope}."
+
+        if (path = @report.config&.path)
+          @io.puts dim("Suppressions from #{path}.")
+        end
+      end
+
+      def count(number, noun) = "#{number} #{noun.pluralize(number)}"
+
+      def colorize(text, key) = @color ? "#{COLORS[key]}#{text}#{COLORS[:reset]}" : text
+
+      def bold(text) = colorize(text, :bold)
+
+      def dim(text) = colorize(text, :dim)
+    end
+  end
+end

--- a/lib/plutonium/doctor/runner.rb
+++ b/lib/plutonium/doctor/runner.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # Runs the checks over every resource of every portal and folds the results
+    # into a {Report}.
+    #
+    # The runner owns everything a check deliberately does not: which portals
+    # exist, how a portal resolves a definition and a policy, whether a check is
+    # switched off, and how duplicates fold together. A check sees one target
+    # and answers about that target.
+    class Runner
+      CHECKS = [
+        Checks::MissingPolicyRule,
+        Checks::AutodetectedPermittedAttributes,
+        Checks::ConditionAsAuthorization,
+        Checks::RedundantFieldDeclaration
+      ].freeze
+
+      # @param only [String, nil] restrict to one portal
+      # @param config [Config]
+      # @param checks [Array<Class>]
+      def initialize(only: nil, config: Config.load, checks: CHECKS)
+        @only = only
+        @config = config
+        @checks = checks.reject { |check| config.disabled?(check.check_name) }
+      end
+
+      def call
+        findings = {}
+        resources = 0
+        portals = Portals.discover(only: @only)
+
+        portals.each do |portal|
+          portal.resources.each do |resource_class|
+            target = build_target(portal, resource_class) { |f| record(findings, f) }
+            next unless target
+            next if target.framework_owned?
+
+            resources += 1
+            @checks.each do |check|
+              run_check(check, target) { |f| record(findings, f) }
+            end
+          end
+        end
+
+        Report.new(
+          findings: findings.values.reject { |f| suppressed?(f) },
+          portals_inspected: portals.size,
+          resources_inspected: resources,
+          checks_run: @checks.map(&:check_name),
+          config: @config
+        )
+      end
+
+      private
+
+      # `disable` is applied to findings as well as to the check list, so that
+      # disabling a check the runner raises itself (`unresolvable_resource`,
+      # `check_failed`) works the same way as disabling one from CHECKS. A
+      # config key that silently does nothing for two of the names it accepts
+      # is worse than not accepting them.
+      def suppressed?(finding)
+        @config.ignored?(finding) || @config.disabled?(finding.check)
+      end
+
+      # Folds a finding in by identity, so one mistake reached through three
+      # portals is reported once with all three named.
+      def record(findings, finding)
+        if (existing = findings[finding.key])
+          existing.merge_scope(finding)
+        else
+          findings[finding.key] = finding
+        end
+      end
+
+      # A check that blows up is reported as a finding rather than taking the
+      # whole run down. A doctor that dies on resource four and never mentions
+      # resources five through forty is worse than one that says "this check
+      # failed here" and keeps going.
+      def run_check(check, target)
+        check.new(target).call.each { |finding| yield finding }
+      rescue => e
+        yield Finding.new(
+          check: :check_failed,
+          severity: :warning,
+          subject: "#{target.resource_class}##{check.check_name}",
+          message: "#{check.check_name} could not run against #{target.resource_class}",
+          details: "#{e.class}: #{e.message}",
+          scope: target.portal.name
+        )
+      end
+
+      # Resolves the definition and policy the way a request in this portal
+      # would. Either one missing is itself worth reporting: the resource is
+      # registered and routed, so the failure is a 500 on first visit rather
+      # than anything the app is protected from.
+      def build_target(portal, resource_class)
+        definition_class = resolve_definition(portal, resource_class)
+        policy_class = resolve_policy(portal, resource_class)
+
+        if definition_class.nil?
+          yield unresolvable(portal, resource_class, "definition", "#{resource_class}Definition")
+          return nil
+        end
+
+        if policy_class.nil?
+          yield unresolvable(portal, resource_class, "policy", "#{resource_class}Policy")
+          return nil
+        end
+
+        Target.new(
+          portal: portal,
+          resource_class: resource_class,
+          definition_class: definition_class,
+          policy_class: policy_class
+        )
+      end
+
+      def unresolvable(portal, resource_class, kind, expected)
+        Finding.new(
+          check: :unresolvable_resource,
+          severity: :error,
+          subject: "#{resource_class}##{kind}",
+          message: "#{resource_class} is registered in #{portal.name} but has no #{kind} class",
+          details: <<~TEXT,
+            Expected #{expected}#{" (or #{portal.namespace}::#{expected})" if portal.namespace}.
+
+            The resource is registered and routed, so the first request for it raises.
+            Generate the missing class, or drop the `register_resource` line.
+          TEXT
+          scope: portal.name
+        )
+      end
+
+      # Mirrors Plutonium::Resource::Controller#resource_definition: portal
+      # namespace first, top level as the fallback.
+      def resolve_definition(portal, resource_class)
+        namespaced = [portal.namespace, "#{resource_class}Definition"].compact.join("::")
+        namespaced.safe_constantize || "#{resource_class}Definition".safe_constantize
+      end
+
+      def resolve_policy(portal, resource_class)
+        ::ActionPolicy.lookup(resource_class, namespace: portal.namespace)
+      rescue ::ActionPolicy::NotFound
+        nil
+      end
+    end
+  end
+end

--- a/lib/plutonium/doctor/target.rb
+++ b/lib/plutonium/doctor/target.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Plutonium
+  module Doctor
+    # A resource as one portal sees it.
+    #
+    # Definition and policy are resolved the way a request resolves them —
+    # portal namespace first, top level as the fallback — so the doctor
+    # inspects the classes that would actually serve the request rather than
+    # the top-level pair a portal may have overridden. See
+    # {Plutonium::Resource::Controller#resource_definition} for the definition
+    # rule and ActionPolicy's namespaced lookup for the policy one.
+    class Target
+      attr_reader :portal, :resource_class, :definition_class, :policy_class
+
+      def initialize(portal:, resource_class:, definition_class:, policy_class:)
+        @portal = portal
+        @resource_class = resource_class
+        @definition_class = definition_class
+        @policy_class = policy_class
+      end
+
+      # Definitions are cheap to build and every check wants the merged,
+      # instance-level view (`defined_actions`, `defined_fields`, …), which only
+      # exists on an instance.
+      def definition
+        @definition ||= definition_class.new
+      end
+
+      # Whether this target is framework-owned rather than application code.
+      # Plutonium registers resources of its own (Async::Run being the obvious
+      # one) and the doctor has nothing useful to say about them: a finding
+      # there is a bug to fix in the gem, not something an application can act
+      # on from its own config.
+      def framework_owned?
+        definition_class.name.to_s.start_with?("Plutonium::") ||
+          resource_class.name.to_s.start_with?("Plutonium::")
+      end
+    end
+  end
+end

--- a/test/generators/doctor_generator_test.rb
+++ b/test/generators/doctor_generator_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators"
+require "rails/generators/test_case"
+require "generators/pu/core/doctor/doctor_generator"
+
+class DoctorGeneratorTest < Rails::Generators::TestCase
+  tests Pu::Core::DoctorGenerator
+  destination Rails.root
+
+  # The generator writes nothing, so there is no dummy app state to restore —
+  # it is a reporter with an exit code, shaped as a generator only so it is
+  # found where every other Plutonium command is.
+  def setup
+  end
+
+  def test_prints_a_report_for_the_application
+    output = run_generator
+
+    assert_match(/resources across/, output)
+    assert_match(/\d+ errors?, \d+ warnings?|No problems found/, output)
+  end
+
+  def test_restricting_to_one_portal_narrows_the_run
+    output = run_generator ["--portal=admin_portal"]
+
+    assert_match(/across 1 portal/, output)
+  end
+
+  # The exit code is the whole point of --strict: a CI step that reports and
+  # then exits 0 is a CI step that never fails.
+  def test_strict_exits_non_zero_on_warnings
+    error = assert_raises(SystemExit) { run_generator ["--strict"] }
+
+    refute_equal 0, error.status
+  end
+
+  def test_without_strict_warnings_do_not_fail_the_run
+    run_generator
+
+    pass
+  end
+end

--- a/test/plutonium/doctor/autodetected_permitted_attributes_test.rb
+++ b/test/plutonium/doctor/autodetected_permitted_attributes_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DoctorBareDefinition < Plutonium::Resource::Definition; end
+
+# Declares nothing — every permitted-attributes call falls through to
+# autodetection.
+class DoctorSilentPolicy < Plutonium::Resource::Policy; end
+
+class DoctorReadOnlyPolicy < Plutonium::Resource::Policy
+  def permitted_attributes_for_read = %i[title]
+end
+
+class DoctorCompletePolicy < Plutonium::Resource::Policy
+  def permitted_attributes_for_create = %i[title]
+
+  def permitted_attributes_for_read = %i[title]
+end
+
+# Covers every read-side entry point without ever defining the base underneath
+# them, so nothing can reach the autodetecting method.
+class DoctorEntryPointPolicy < Plutonium::Resource::Policy
+  def permitted_attributes_for_create = %i[title]
+
+  def permitted_attributes_for_index = %i[title]
+
+  def permitted_attributes_for_show = %i[title]
+end
+
+class Plutonium::Doctor::AutodetectedPermittedAttributesTest < Minitest::Test
+  include DoctorHelpers
+
+  Check = Plutonium::Doctor::Checks::AutodetectedPermittedAttributes
+
+  def test_reports_both_bases_when_the_policy_declares_nothing
+    findings = run_check(Check, target(DoctorSilentPolicy))
+
+    assert_equal 2, findings.size
+    assert_equal(
+      ["Blogging::Post#permitted_attributes_for_create", "Blogging::Post#permitted_attributes_for_read"],
+      findings.map(&:subject).sort
+    )
+    assert findings.all?(&:error?)
+  end
+
+  def test_reports_only_the_base_that_is_still_missing
+    finding = run_check(Check, target(DoctorReadOnlyPolicy)).sole
+
+    assert_equal "Blogging::Post#permitted_attributes_for_create", finding.subject
+  end
+
+  def test_says_nothing_when_both_bases_are_declared
+    assert_empty run_check(Check, target(DoctorCompletePolicy))
+  end
+
+  def test_says_nothing_when_every_entry_point_answers_for_itself
+    # permitted_attributes_for_read is undefined, but nothing reaches it:
+    # index and show answer directly, and export delegates to index.
+    assert_empty run_check(Check, target(DoctorEntryPointPolicy))
+  end
+
+  def test_names_the_entry_points_that_reach_the_missing_base
+    finding = run_check(Check, target(DoctorReadOnlyPolicy)).sole
+
+    assert_match(/permitted_attributes_for_new/, finding.details)
+    assert_match(/permitted_attributes_for_create/, finding.details)
+    assert_match(/raise outside development/, finding.message)
+  end
+
+  def test_suggests_real_columns_so_the_fix_is_copy_pasteable
+    finding = run_check(Check, target(DoctorReadOnlyPolicy)).sole
+    suggested = finding.details[/%i\[([^\]]*)\]/, 1].to_s.split
+
+    refute_empty suggested, "the suggested override should name real fields, not an empty list"
+    assert (suggested - Blogging::Post.resource_field_names.map(&:to_s)).empty?,
+      "suggested #{suggested.inspect} should all be fields of Blogging::Post"
+    refute_includes suggested, Blogging::Post.primary_key
+    refute_includes suggested, "created_at"
+  end
+
+  # The delegation map in the check is hardcoded, because the delegation lives
+  # in method bodies and cannot be read off the class. This locks it to the real
+  # Plutonium::Resource::Policy: if a default ever stops delegating where the map
+  # says it does, this fails rather than the check quietly going blind.
+  def test_delegation_map_matches_the_base_policy
+    Check::ENTRY_POINTS.each do |entry|
+      assert_equal probed_base(entry), resolved_base(entry),
+        "#{entry} reaches a different base than Checks::AutodetectedPermittedAttributes::DELEGATIONS claims"
+    end
+  end
+
+  private
+
+  # Where an entry point ACTUALLY lands, by making autodetection announce itself.
+  def probed_base(entry)
+    probe = Class.new(Plutonium::Resource::Policy) do
+      define_method(:autodetect_permitted_fields) { |name| throw :autodetected, name }
+    end.new(record: Blogging::Post, user: Object.new, entity_scope: nil)
+
+    catch(:autodetected) do
+      probe.public_send(entry)
+      nil
+    end
+  end
+
+  # Where the check's map says it lands, with no application override anywhere.
+  def resolved_base(entry)
+    current = entry
+    current = Check::DELEGATIONS[current] until current.nil? || Check::BASES.include?(current)
+    current
+  end
+
+  def target(policy_class)
+    doctor_target(
+      resource_class: Blogging::Post,
+      definition_class: DoctorBareDefinition,
+      policy_class: policy_class
+    )
+  end
+end

--- a/test/plutonium/doctor/condition_as_authorization_test.rb
+++ b/test/plutonium/doctor/condition_as_authorization_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DoctorConditionDefinition < Plutonium::Resource::Definition
+  # Reads as an authorization rule.
+  action :publish, record_action: true, condition: -> { current_user.admin? }
+  # Reads as presentation.
+  action :preview, record_action: true, condition: -> { object&.draft? }
+  # No condition at all.
+  action :syndicate, record_action: true
+end
+
+# Every custom predicate delegates: written by the application, but answering a
+# different question than the condition asks.
+class DoctorDelegatingPolicy < Plutonium::Resource::Policy
+  def publish? = update?
+
+  def preview? = update?
+
+  def syndicate? = update?
+end
+
+# publish? decides for itself, on the user.
+class DoctorDecidingPolicy < DoctorDelegatingPolicy
+  def publish? = user.admin?
+end
+
+class Plutonium::Doctor::ConditionAsAuthorizationTest < Minitest::Test
+  include DoctorHelpers
+
+  Check = Plutonium::Doctor::Checks::ConditionAsAuthorization
+
+  def test_reports_a_condition_that_is_the_only_user_check
+    finding = run_check(Check, target(DoctorDelegatingPolicy)).sole
+
+    assert_equal :condition_as_authorization, finding.check
+    assert_equal :warning, finding.severity
+    assert_equal "Blogging::Post#publish", finding.subject
+    assert_match(/checks the user in `condition:`/, finding.message)
+  end
+
+  def test_quotes_the_condition_so_the_reader_can_judge_it
+    finding = run_check(Check, target(DoctorDelegatingPolicy)).sole
+
+    assert_match(/current_user\.admin\?/, finding.details)
+    assert_match(/route stays live/, finding.details)
+  end
+
+  def test_leaves_a_presentation_condition_alone
+    subjects = run_check(Check, target(DoctorDelegatingPolicy)).map(&:subject)
+
+    refute_includes subjects, "Blogging::Post#preview"
+  end
+
+  def test_leaves_an_action_with_no_condition_alone
+    subjects = run_check(Check, target(DoctorDelegatingPolicy)).map(&:subject)
+
+    refute_includes subjects, "Blogging::Post#syndicate"
+  end
+
+  # The case the first cut of this check missed: the app DID write publish?, so
+  # an owner-based test goes quiet, but a bare delegation checks nothing about
+  # the user and the condition is still the only gate.
+  def test_a_delegating_predicate_does_not_count_as_deciding
+    finding = run_check(Check, target(DoctorDelegatingPolicy)).sole
+
+    assert_equal "Blogging::Post#publish", finding.subject
+  end
+
+  def test_says_nothing_once_the_policy_checks_the_user_itself
+    assert_empty run_check(Check, target(DoctorDecidingPolicy))
+  end
+
+  # A CRUD action hidden by a condition while the inherited predicate still
+  # allows it — same bug, reached through the framework's own actions.
+  def test_reports_a_crud_action_hidden_by_a_condition
+    findings = run_check(Check, target(DoctorDelegatingPolicy, definition: DoctorHiddenDestroyDefinition))
+
+    assert_equal "Blogging::Post#destroy", findings.sole.subject
+  end
+
+  # A missing predicate belongs to MissingPolicyRule.
+  def test_defers_a_missing_predicate_to_the_other_check
+    assert_empty run_check(Check, target(DoctorNoRulesPolicy))
+  end
+
+  private
+
+  def target(policy_class, definition: DoctorConditionDefinition)
+    doctor_target(
+      resource_class: Blogging::Post,
+      definition_class: definition,
+      policy_class: policy_class
+    )
+  end
+end
+
+class DoctorHiddenDestroyDefinition < Plutonium::Resource::Definition
+  action :destroy, record_action: true, condition: -> { current_user.admin? }
+end
+
+class DoctorNoRulesPolicy < Plutonium::Resource::Policy; end

--- a/test/plutonium/doctor/config_test.rb
+++ b/test/plutonium/doctor/config_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class Plutonium::Doctor::ConfigTest < Minitest::Test
+  Config = Plutonium::Doctor::Config
+
+  def test_no_file_disables_nothing
+    with_config(nil) do |config|
+      refute config.disabled?(:redundant_field_declaration)
+      assert_nil config.path
+    end
+  end
+
+  def test_reads_disabled_checks
+    with_config(<<~YAML) do |config|
+      disable:
+        - redundant_field_declaration
+    YAML
+      assert config.disabled?(:redundant_field_declaration)
+      refute config.disabled?(:missing_policy_rule)
+    end
+  end
+
+  def test_disabled_accepts_a_string_or_a_symbol
+    with_config("disable:\n  - missing_policy_rule\n") do |config|
+      assert config.disabled?(:missing_policy_rule)
+      assert config.disabled?("missing_policy_rule")
+    end
+  end
+
+  def test_ignores_a_finding_by_the_key_the_report_prints
+    with_config(<<~YAML) do |config|
+      ignore:
+        - missing_policy_rule:Blogging::Post#publish
+    YAML
+      assert config.ignored?(finding("Blogging::Post#publish"))
+      refute config.ignored?(finding("Blogging::Post#archive"))
+    end
+  end
+
+  def test_an_empty_file_is_not_an_error
+    with_config("") do |config|
+      refute config.disabled?(:missing_policy_rule)
+    end
+  end
+
+  def test_records_the_path_it_read_so_the_report_can_name_it
+    with_config("disable: []\n") do |config|
+      assert_equal ".plutonium-doctor.yml", File.basename(config.path)
+    end
+  end
+
+  private
+
+  def finding(subject)
+    Plutonium::Doctor::Finding.new(
+      check: :missing_policy_rule,
+      severity: :error,
+      subject: subject,
+      message: "x"
+    )
+  end
+
+  def with_config(contents)
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, Config::DEFAULT_FILENAME), contents) if contents
+      yield Config.load(root: dir)
+    end
+  end
+end

--- a/test/plutonium/doctor/missing_policy_rule_test.rb
+++ b/test/plutonium/doctor/missing_policy_rule_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A definition with one custom action beyond the CRUD set.
+class DoctorPublishDefinition < Plutonium::Resource::Definition
+  action :publish, record_action: true
+  action :archive, bulk_action: true
+end
+
+# Answers for :publish, silent about :archive.
+class DoctorHalfCoveredPolicy < Plutonium::Resource::Policy
+  def publish? = update?
+
+  def permitted_attributes_for_create = %i[title]
+
+  def permitted_attributes_for_read = %i[title]
+end
+
+class DoctorFullyCoveredPolicy < DoctorHalfCoveredPolicy
+  def archive? = update?
+end
+
+# The shape Plutonium itself generates for a kanban column's enter_interaction.
+class DoctorHiddenActionDefinition < Plutonium::Resource::Definition
+  action :blocked_enter_interaction, hidden: true
+end
+
+class Plutonium::Doctor::MissingPolicyRuleTest < Minitest::Test
+  include DoctorHelpers
+
+  Check = Plutonium::Doctor::Checks::MissingPolicyRule
+
+  def test_reports_an_action_with_no_policy_predicate
+    findings = run_check(Check, target(DoctorHalfCoveredPolicy))
+
+    assert_equal 1, findings.size
+    finding = findings.sole
+
+    assert_equal :missing_policy_rule, finding.check
+    assert_equal :error, finding.severity
+    assert_equal "Blogging::Post#archive", finding.subject
+    assert_match(/`archive` has no `archive\?`/, finding.message)
+    assert_match(/DoctorHalfCoveredPolicy/, finding.message)
+  end
+
+  def test_says_nothing_when_every_action_is_covered
+    assert_empty run_check(Check, target(DoctorFullyCoveredPolicy))
+  end
+
+  def test_ignores_the_crud_actions_plutonium_answers_for_itself
+    # new/show/edit/destroy are declared by every definition and answered by
+    # Plutonium::Resource::Policy, so a bare pairing must stay quiet.
+    findings = run_check(Check, target(DoctorFullyCoveredPolicy, definition: Plutonium::Resource::Definition))
+
+    assert_empty findings
+  end
+
+  def test_names_the_action_kind_so_the_message_says_what_broke
+    finding = run_check(Check, target(DoctorHalfCoveredPolicy)).sole
+
+    assert_match(/Bulk action/, finding.message)
+  end
+
+  # `hidden: true` means the action renders on no surface, so the "button that
+  # silently never appears" failure cannot happen — and it is how the framework
+  # builds a kanban column's enter_interaction, which is predicate-less on
+  # purpose because kanban_move? authorizes the drop. Flagging those would make
+  # the doctor wrong about every board Plutonium generates.
+  def test_exempts_a_hidden_action
+    assert_empty run_check(Check, target(DoctorHalfCoveredPolicy, definition: DoctorHiddenActionDefinition))
+  end
+
+  def test_carries_the_portal_it_was_seen_in
+    finding = run_check(Check, target(DoctorHalfCoveredPolicy, portal: doctor_portal("AdminPortal"))).sole
+
+    assert_equal ["AdminPortal"], finding.scopes
+  end
+
+  def test_suppression_key_is_the_check_and_subject
+    finding = run_check(Check, target(DoctorHalfCoveredPolicy)).sole
+
+    assert_equal "missing_policy_rule:Blogging::Post#archive", finding.key
+  end
+
+  private
+
+  def target(policy_class, definition: DoctorPublishDefinition, portal: doctor_portal)
+    doctor_target(
+      resource_class: Blogging::Post,
+      definition_class: definition,
+      policy_class: policy_class,
+      portal: portal
+    )
+  end
+end

--- a/test/plutonium/doctor/redundant_field_declaration_test.rb
+++ b/test/plutonium/doctor/redundant_field_declaration_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DoctorDeclarationsDefinition < Plutonium::Resource::Definition
+  # Dead: repeats what the model already said.
+  field :title
+  display :body
+  column :created_at
+
+  # Alive: each overrides something.
+  field :summary, as: :markdown
+  display :published_at, wrapper: {class: "col-span-2"}
+  column :status, condition: -> { true }
+  field :byline do
+    "written by someone"
+  end
+
+  # Never checked — defined_inputs.keys is a source list for nested inputs,
+  # structured inputs and wizard steps, so a bare input can be load-bearing.
+  input :slug
+end
+
+class DoctorDeclarationsPolicy < Plutonium::Resource::Policy
+  def permitted_attributes_for_create = %i[title]
+
+  def permitted_attributes_for_read = %i[title]
+end
+
+class Plutonium::Doctor::RedundantFieldDeclarationTest < Minitest::Test
+  include DoctorHelpers
+
+  Check = Plutonium::Doctor::Checks::RedundantFieldDeclaration
+
+  def test_reports_every_bare_declaration
+    subjects = findings.map(&:subject)
+
+    assert_includes subjects, "DoctorDeclarationsDefinition#field:title"
+    assert_includes subjects, "DoctorDeclarationsDefinition#display:body"
+    assert_includes subjects, "DoctorDeclarationsDefinition#column:created_at"
+    assert_equal 3, findings.size
+  end
+
+  def test_leaves_a_declaration_carrying_options_alone
+    subjects = findings.map(&:subject)
+
+    refute_includes subjects, "DoctorDeclarationsDefinition#field:summary"
+    refute_includes subjects, "DoctorDeclarationsDefinition#display:published_at"
+    refute_includes subjects, "DoctorDeclarationsDefinition#column:status"
+  end
+
+  def test_leaves_a_declaration_carrying_a_block_alone
+    refute_includes findings.map(&:subject), "DoctorDeclarationsDefinition#field:byline"
+  end
+
+  # defined_inputs.keys IS the field set for nested resource fields, structured
+  # inputs and wizard steps, so a bare input is not dead code there. Warning on
+  # it would teach people to ignore the doctor.
+  def test_never_reports_an_input
+    assert_empty findings.select { |f| f.subject.include?("input:") }
+  end
+
+  def test_is_a_warning_not_an_error
+    assert findings.all?(&:warning?)
+  end
+
+  def test_points_at_the_policy_for_making_a_field_appear
+    finding = findings.find { |f| f.subject.end_with?("field:title") }
+
+    assert_match(/permitted_attributes_for_\*/, finding.details)
+    assert_match(/can be deleted/, finding.message)
+  end
+
+  private
+
+  def findings
+    @findings ||= run_check(Check, doctor_target(
+      resource_class: Blogging::Post,
+      definition_class: DoctorDeclarationsDefinition,
+      policy_class: DoctorDeclarationsPolicy
+    ))
+  end
+end

--- a/test/plutonium/doctor/reporter_test.rb
+++ b/test/plutonium/doctor/reporter_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stringio"
+
+class Plutonium::Doctor::ReporterTest < Minitest::Test
+  Reporter = Plutonium::Doctor::Reporter
+  Report = Plutonium::Doctor::Report
+  Finding = Plutonium::Doctor::Finding
+
+  def test_prints_findings_worst_first
+    output = render(findings: [warning, error])
+
+    assert_operator output.index("ERROR"), :<, output.index("WARNING")
+  end
+
+  def test_groups_findings_of_the_same_check_together
+    output = render(findings: [error, error("Blogging::Post#archive")])
+
+    assert_includes output, "missing_policy_rule"
+    assert_equal 1, output.scan(/^ERROR/).size
+    assert_includes output, "(2)"
+  end
+
+  def test_prints_the_suppression_key_under_every_finding
+    output = render(findings: [error])
+
+    assert_includes output, "missing_policy_rule:Blogging::Post#publish"
+  end
+
+  def test_names_the_portals_a_finding_was_seen_in
+    output = render(findings: [error])
+
+    assert_includes output, "AdminPortal, OrgPortal"
+  end
+
+  def test_summarises_counts_and_what_was_looked_at
+    output = render(findings: [error, warning])
+
+    assert_includes output, "1 error, 1 warning"
+    assert_includes output, "3 resources across 2 portals"
+  end
+
+  def test_says_so_plainly_when_there_is_nothing_to_report
+    output = render(findings: [])
+
+    assert_includes output, "No problems found"
+  end
+
+  # "Nothing was wrong" and "nothing was looked at" are different answers, and a
+  # checker that renders them alike is how a CI job passes without running.
+  def test_distinguishes_a_clean_run_from_an_empty_one
+    output = render(findings: [], resources: 0, portals: 0)
+
+    assert_includes output, "No Plutonium resources found"
+    refute_includes output, "No problems found"
+  end
+
+  def test_emits_no_escape_codes_when_colour_is_off
+    refute_includes render(findings: [error]), "\e["
+  end
+
+  private
+
+  def error(subject = "Blogging::Post#publish")
+    Finding.new(
+      check: :missing_policy_rule,
+      severity: :error,
+      subject: subject,
+      message: "`publish` has no `publish?`",
+      details: "Add the predicate.",
+      scope: ["AdminPortal", "OrgPortal"]
+    )
+  end
+
+  def warning
+    Finding.new(
+      check: :redundant_field_declaration,
+      severity: :warning,
+      subject: "PostDefinition#field:title",
+      message: "`field :title` declares nothing",
+      details: "Delete the line.",
+      scope: "AdminPortal"
+    )
+  end
+
+  def render(findings:, resources: 3, portals: 2)
+    io = StringIO.new
+    report = Report.new(
+      findings: findings,
+      portals_inspected: portals,
+      resources_inspected: resources,
+      checks_run: [:missing_policy_rule]
+    )
+    Reporter.new(report, io: io, color: false).call
+    io.string
+  end
+end

--- a/test/plutonium/doctor/runner_test.rb
+++ b/test/plutonium/doctor/runner_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Plutonium::Doctor::RunnerTest < Minitest::Test
+  include DoctorHelpers
+
+  Runner = Plutonium::Doctor::Runner
+  Config = Plutonium::Doctor::Config
+
+  def setup
+    Rails.application.eager_load!
+    Rails.application.reload_routes!
+  end
+
+  def test_inspects_the_portals_and_resources_of_the_application
+    report = run_doctor
+
+    assert_operator report.portals_inspected, :>, 0
+    assert_operator report.resources_inspected, :>, 0
+    refute report.nothing_inspected?
+  end
+
+  def test_the_dummy_application_has_no_errors
+    # A standing assertion about the fixture app as much as about the doctor:
+    # an error appearing here means either a real mistake in test/dummy or a
+    # check that is wrong about the framework's own output.
+    report = run_doctor
+
+    assert_empty report.errors.map(&:message)
+  end
+
+  # Uses a fixture check rather than whatever the dummy app happens to declare,
+  # so tidying a definition in test/dummy cannot quietly stop exercising dedupe.
+  def test_folds_one_mistake_reached_through_several_portals_into_one_finding
+    report = run_doctor(checks: [ConstantCheck])
+    keys = report.findings.map(&:key)
+
+    assert_equal keys.uniq, keys, "findings should be unique by key"
+
+    shared = report.findings.find { |f| f.scopes.size > 1 }
+    refute_nil shared, "a resource mounted in two portals should yield one finding naming both"
+    assert_operator report.resources_inspected, :>, report.findings.size
+  end
+
+  def test_real_findings_are_also_unique_by_key
+    keys = run_doctor.findings.map(&:key)
+
+    assert_equal keys.uniq, keys
+  end
+
+  def test_a_disabled_check_never_runs
+    report = run_doctor(config: Config.new(disabled: [:redundant_field_declaration]))
+
+    assert_empty report.findings.select { |f| f.check == :redundant_field_declaration }
+    refute_includes report.checks_run, :redundant_field_declaration
+  end
+
+  def test_an_ignored_key_is_dropped_from_the_report
+    key = run_doctor(checks: [ConstantCheck]).findings.first.key
+
+    report = run_doctor(checks: [ConstantCheck], config: Config.new(ignored: [key]))
+
+    refute_includes report.findings.map(&:key), key
+  end
+
+  def test_restricting_to_one_portal_narrows_the_run
+    report = run_doctor(only: "admin_portal")
+
+    assert_equal 1, report.portals_inspected
+    assert report.findings.all? { |f| f.scopes == ["AdminPortal"] }
+  end
+
+  # disable also applies to the checks the runner raises itself, which are not
+  # in CHECKS and so cannot be filtered out of the check list.
+  def test_disable_covers_a_runner_owned_check_too
+    report = run_doctor(checks: [ExplodingCheck], config: Config.new(disabled: [:check_failed]))
+
+    assert_empty report.findings
+  end
+
+  def test_a_check_that_raises_is_reported_rather_than_taking_the_run_down
+    report = run_doctor(checks: [ExplodingCheck])
+
+    assert_operator report.findings.size, :>, 0
+    assert report.findings.all? { |f| f.check == :check_failed }
+    assert_match(/could not run/, report.findings.first.message)
+    assert_match(/deliberate/, report.findings.first.details)
+  end
+
+  def test_pass_depends_on_strictness_when_only_warnings_are_present
+    report = run_doctor
+
+    assert_empty report.errors
+    assert report.pass?
+    refute report.pass?(strict: true) if report.warnings.any?
+  end
+
+  def test_skips_plutonium_own_resources
+    # Async::Run is registered like any other resource; a finding against it is
+    # a bug to fix in the gem, not something an application can act on.
+    report = run_doctor
+
+    refute report.findings.any? { |f| f.subject.include?("Plutonium::") }
+  end
+
+  private
+
+  def run_doctor(only: nil, config: Config.new, checks: Runner::CHECKS)
+    Runner.new(only: only, config: config, checks: checks).call
+  end
+
+  # Reports once per resource, with a key that does not vary by portal — the
+  # shape a shared definition produces when several portals mount it.
+  class ConstantCheck < Plutonium::Doctor::Check
+    def self.check_name = :constant
+
+    def call
+      [finding(subject: target.resource_class.name, message: "always")]
+    end
+  end
+
+  class ExplodingCheck < Plutonium::Doctor::Check
+    def self.check_name = :exploding
+
+    def call
+      raise "deliberate failure"
+    end
+  end
+end

--- a/test/support/doctor_helpers.rb
+++ b/test/support/doctor_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Builds the one input a doctor check takes, so a check test can be about the
+# check rather than about portal discovery.
+module DoctorHelpers
+  def doctor_portal(name = "TestPortal", namespace: nil)
+    Plutonium::Doctor::Portals::Portal.new(
+      name: name,
+      engine: nil,
+      namespace: namespace,
+      resources: []
+    )
+  end
+
+  def doctor_target(resource_class:, definition_class:, policy_class:, portal: doctor_portal)
+    Plutonium::Doctor::Target.new(
+      portal: portal,
+      resource_class: resource_class,
+      definition_class: definition_class,
+      policy_class: policy_class
+    )
+  end
+
+  def run_check(check_class, target)
+    check_class.new(target).call
+  end
+end


### PR DESCRIPTION
Plutonium raises wherever it can: Policy.method_added catches an
instance-method relation_scope, display_layout raises on a copied
`columns:`, the register refuses an unprepared model. What is left over
is code that is legal, runs, and quietly does nothing.

pu:core:doctor boots the app, walks every portal's registered resources,
and reports four such cases. It writes nothing, and exits non-zero on
errors (or on anything at all with --strict).

  missing_policy_rule (error)
    An action with no <action>? on the policy. ActionPolicy answers false
    for a rule that does not exist, so the button silently never renders.
    Hidden actions are exempt: they render on no surface, and a kanban
    column's enter_interaction is predicate-less by design because
    kanban_move? authorizes the drop.

  autodetected_permitted_attributes (error)
    A policy that never declares permitted_attributes_for_create/_read.
    autodetect_permitted_fields raises outside development and only logs
    in it, so this works locally and 500s on deploy. Follows Plutonium's
    delegation chain from each entry point, so a policy answering _index
    and _show is not flagged for the _read nothing reaches.

  condition_as_authorization (warning)
    A condition: doing the user check the policy predicate does not. The
    route stays live, so a direct POST runs anyway. Both halves are
    judged by the same token list, which is what catches the common
    shape: `def publish? = update?` is written by the app but decides
    nothing about the user.

  redundant_field_declaration (warning)
    A bare field/display/column. The surfaces only look declarations up
    by name while iterating a list that comes from the policy, so one
    carrying no options is read and discarded. `input` is never checked:
    defined_inputs.keys is a source list for nested inputs, structured
    inputs and wizard steps.

Definitions and policies are resolved per portal exactly as a request
resolves them, so a portal override is checked rather than the top-level
pair it replaced. One mistake reached through several portals folds into
one finding naming them all.

Suppression ships from the first release, via .plutonium-doctor.yml:
every check is a judgement about intent, and a checker with no way to
say "yes, I meant that" gets muted wholesale instead. Each finding
prints its own suppression key.

Adds the reference page, and points the router and behavior skills at it.