### PR TITLE
fix(resource): cover auto-detected attachments in attachment_input_keys

### DIFF
--- a/lib/plutonium/resource/controller.rb
+++ b/lib/plutonium/resource/controller.rb
@@ -188,14 +188,19 @@ module Plutonium
         end
       end
 
-      # Attachment/file input names (as Strings) declared on the current
-      # definition — inputs whose `as:` is a file type (`:file`/`:uppy`/
-      # `:attachment`). Excluded from the extraction-record pre-assignment so a
-      # single-read Rack upload isn't consumed before create/update reads it.
+      # Attachment/file input names (as Strings) for the current resource —
+      # inputs declared with a file `as:` (`:file`/`:uppy`/`:attachment`)
+      # unioned with the attachments reflected on the model, so auto-detected
+      # attachments (no `input` declaration) are covered too. Excluded from the
+      # extraction-record pre-assignment so a single-read Rack upload isn't
+      # consumed before create/update reads it.
       def attachment_input_keys
-        current_definition.defined_inputs.filter_map { |name, config|
+        declared = current_definition.defined_inputs.filter_map { |name, config|
           name.to_s if Plutonium::Definition::InputAliases.file_input?(config.dig(:options, :as))
         }
+        reflected = (resource_class.has_one_attached_field_names + resource_class.has_many_attached_field_names)
+          .map(&:to_s)
+        declared | reflected
       end
 
       # Returns the resource parameters, including scoped and parent parameters

--- a/test/dummy/app/models/shrine_doc.rb
+++ b/test/dummy/app/models/shrine_doc.rb
@@ -8,4 +8,7 @@ class ShrineDoc < ApplicationRecord
   include ActiveShrine::Model
 
   has_one_attached :file
+  # Deliberately NOT declared as an input in any definition — exercises the
+  # auto-detected attachment path in resource param extraction.
+  has_one_attached :banner
 end

--- a/test/dummy/app/policies/shrine_doc_policy.rb
+++ b/test/dummy/app/policies/shrine_doc_policy.rb
@@ -1,9 +1,9 @@
 class ShrineDocPolicy < ::ResourcePolicy
   def permitted_attributes_for_create
-    [:title, :file]
+    [:title, :file, :banner]
   end
 
   def permitted_attributes_for_read
-    [:title, :file, :created_at, :updated_at]
+    [:title, :file, :banner, :created_at, :updated_at]
   end
 end

--- a/test/integration/admin_portal/shrine_doc_upload_test.rb
+++ b/test/integration/admin_portal/shrine_doc_upload_test.rb
@@ -41,4 +41,32 @@ class AdminPortal::ShrineDocUploadTest < ActionDispatch::IntegrationTest
     assert_equal "Report", doc.title
     assert doc.file.present?, "expected the uploaded file to be attached (not consumed during extraction)"
   end
+
+  # Regression for #113: attachment_input_keys only covered inputs explicitly
+  # declared with a file `as:` (:file/:uppy/:attachment). An AUTO-DETECTED
+  # attachment (ShrineDoc's :banner — `has_one_attached` with no `input`
+  # declaration in the definition) was invisible to the guard, got assigned to
+  # the throwaway extraction record, and its single-read upload was consumed —
+  # so the real assignment in create/update raised "IOError: closed stream".
+  test "an upload for an auto-detected (undeclared) attachment survives param extraction" do
+    assert_difference -> { ShrineDoc.count }, 1 do
+      post "/admin/shrine_docs", params: {shrine_doc: {title: "Auto", banner: multipart_png("banner")}}
+    end
+    assert_response :redirect
+
+    doc = ShrineDoc.order(:id).last
+    assert_equal "Auto", doc.title
+    assert doc.banner.present?, "expected the auto-detected attachment to attach (not consumed during extraction)"
+  end
+
+  test "an upload for an auto-detected attachment survives param extraction on update" do
+    doc = ShrineDoc.create!(title: "Before")
+
+    patch "/admin/shrine_docs/#{doc.id}", params: {shrine_doc: {title: "After", banner: multipart_png("banner")}}
+    assert_response :redirect
+
+    doc.reload
+    assert_equal "After", doc.title
+    assert doc.banner.present?, "expected the auto-detected attachment to attach (not consumed during extraction)"
+  end
 end

--- a/test/plutonium/resource/controller_test.rb
+++ b/test/plutonium/resource/controller_test.rb
@@ -229,6 +229,25 @@ class Plutonium::Resource::ControllerTest < Minitest::Test
     refute_includes keys, "body", "a component-class input is not an attachment input"
   end
 
+  # Regression (#113): attachment_input_keys only covered inputs explicitly
+  # declared with a file `as:`. An auto-detected attachment (reflected on the
+  # model, no `input` declaration in the definition) was invisible, so the
+  # extraction record consumed its single-read upload and the real
+  # create/update assignment raised "IOError: closed stream".
+
+  def test_attachment_input_keys_includes_reflected_model_attachments
+    definition = Class.new(CommentDefinition).new # declares no file inputs
+
+    controller = SubmittedParamsTestController.new
+    controller.instance_variable_set(:@current_definition, definition)
+    controller.define_singleton_method(:resource_class) { ShrineDoc }
+
+    keys = controller.send(:attachment_input_keys)
+
+    assert_includes keys, "file", "reflected attachments should be excluded from pre-assignment"
+    assert_includes keys, "banner", "auto-detected (undeclared) attachments should be excluded from pre-assignment"
+  end
+
   # Test override_entity_scoping_params uses detected association
 
   def test_override_entity_scoping_params_uses_detected_association


### PR DESCRIPTION
Fixes #113

## Problem

`attachment_input_keys` only inspected `defined_inputs`, so it covered attachments explicitly declared with `input :x, as: :file`/`:uppy`/`:attachment` but missed auto-detected ones. An attachment the definition never declares an input for was invisible to the guard in `submitted_resource_params`, got assigned to the throwaway extraction record, and its single-read Rack upload was consumed (Shrine's attacher reads it to EOF and closes it on the first cache write). The real assignment in create/update then read a closed stream and 500ed with `IOError: closed stream`.

## Fix

Union the declared file-input names with the model's reflected attachment names, via the existing `has_one_attached_field_names` and `has_many_attached_field_names` helpers (the same introspection `eager_loading.rb` uses; they return `[]` for models without attachment reflection). The exclusion now covers any attachment regardless of whether the definition declares an `as:`.

## Tests

- Reproduced first: gave the dummy `ShrineDoc` a second attachment (`has_one_attached :banner`) with no `input` declaration in its definition, and added create + update integration tests posting a raw multipart upload for it. Both failed with the exact `IOError: closed stream` before the fix and pass after.
- Added a unit test asserting `attachment_input_keys` includes reflected attachments even when the definition declares no file inputs.
- Full rails-8.1 suite: 3173 tests, no new failures (the two failing tests, `SqliteTypeAliasTest` and `OrgPortal::DispatchRedirectTest`, fail identically on master without this change).
- `standardrb` clean on all changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_013AeGGRPRiNtNMLemuDuKm3)_