### PR TITLE
fix(wizard): inherit width in subclasses and wrap long stepper labels

### DIFF
--- a/lib/plutonium/wizard/dsl.rb
+++ b/lib/plutonium/wizard/dsl.rb
@@ -344,6 +344,7 @@ module Plutonium
           subclass.instance_variable_set(:@anchor_resolver, @anchor_resolver)
           subclass.instance_variable_set(:@navigation, @navigation)
           subclass.instance_variable_set(:@stepper, @stepper)
+          subclass.instance_variable_set(:@width, @width)
           subclass.instance_variable_set(:@on_relaunch, @on_relaunch)
           subclass.instance_variable_set(:@cleanup_after, @cleanup_after)
           subclass.instance_variable_set(:@cleanup_after_set, @cleanup_after_set)

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -975,6 +975,9 @@ html.pu-rail-pinned .icon-rail-pin-expand {
 }
 .pu-wizard-steps .pu-step-label {
   @apply block mt-2 font-bold; font-size: .8rem; color: var(--pu-text-muted);
+  /* A 13+ step wizard gives each label a narrow column; without this a single
+     long word ("organisation") overflows and collides with its neighbours. */
+  overflow-wrap: anywhere; hyphens: auto;
 }
 .pu-wizard-steps a.pu-step-link:hover .pu-step-label { @apply underline; }
 

--- a/test/plutonium/wizard/width_test.rb
+++ b/test/plutonium/wizard/width_test.rb
@@ -66,4 +66,24 @@ class Plutonium::Wizard::WidthTest < Minitest::Test
       assert_equal :xl, klass.width, "reading must not reset the configured width"
     end
   end
+
+  # A shared base class is the normal way to give a family of wizards one look
+  # (`class IntakeWizard < Plutonium::Wizard::Base; width :xl; end`). Without
+  # this the subclass silently fell back to the configured default.
+  def test_width_is_inherited
+    with_config(wizards: :md) do
+      base = wizard { width :xl }
+      assert_equal :xl, Class.new(base).width, "subclass inherits the declared width"
+      assert_equal :xl, Class.new(Class.new(base)).width, "and down the chain"
+    end
+  end
+
+  def test_subclass_can_override_the_inherited_width
+    with_config(wizards: :md) do
+      base = wizard { width :xl }
+      sub = Class.new(base) { width :sm }
+      assert_equal :sm, sub.width
+      assert_equal :xl, base.width, "the subclass must not mutate its parent"
+    end
+  end
 end


### PR DESCRIPTION
## Two fixes for wizards with a shared base class and many steps

### 1. `width` was not inherited

`Wizard::Base.inherited` copies `@stepper`, `@navigation`, `@anchor_resolver`, `@cleanup_after` and the rest — but not `@width`. So the normal way to give a family of wizards one look silently does nothing:

```ruby
class IntakeWizard < Plutonium::Wizard::Base
  width :xl
end

class SoleProprietorshipWizard < IntakeWizard   # falls back to config.wizards.width
end
```

Every subclass reverted to the global default, and nothing at the call site hinted at why — the `width :xl` line is right there in the parent. One line added next to the neighbouring `instance_variable_set` calls.

Two regression tests cover it: the width propagates down a subclass chain, and a subclass overriding it does not mutate its parent.

### 2. Long stepper labels overflowed

At 13+ steps a label column is narrower than a single long word, so `"organisation"` ran into its neighbours. `.pu-wizard-steps .pu-step-label` now gets `overflow-wrap: anywhere; hyphens: auto;`.

Found while building a 13–16 step business registration intake on 0.64.

## Testing

`bundle exec appraisal rails-8.1 rake test TEST="test/plutonium/wizard/*_test.rb"` → 241 tests, 543 assertions, 0 failures, 0 errors, 0 skips.