### PR TITLE
feat(query): reserve built-in control names for filters

### DIFF
--- a/lib/plutonium/resource/query_object.rb
+++ b/lib/plutonium/resource/query_object.rb
@@ -13,6 +13,12 @@ module Plutonium
 
       attr_accessor :default_sort_config, :default_scope_name
 
+      # Keys the query object reserves under the `q` namespace for built-in
+      # controls (e.g. `q[scope]`, `q[sort_fields]`). A filter sharing one of
+      # these names would collide with the control in the URL and in the filter
+      # form's hidden state, so defining one is rejected — see #define_filter.
+      RESERVED_FILTER_NAMES = %i[search scope sort_fields sort_directions].freeze
+
       # Initializes a QueryObject with the given resource_class and parameters.
       #
       # @param resource_class [Object] The resource class.
@@ -32,7 +38,13 @@ module Plutonium
       #
       # @param name [Symbol] The name of the filter.
       # @param body [Proc, nil] The body of the filter.
+      # @raise [ArgumentError] if the name collides with a reserved query control.
       def define_filter(name, body, &)
+        if RESERVED_FILTER_NAMES.include?(name.to_sym)
+          raise ArgumentError,
+            "filter name :#{name} is reserved — the query string uses q[#{name}] as a " \
+            "built-in control (one of: #{RESERVED_FILTER_NAMES.join(", ")}). Rename the filter."
+        end
         filter_definitions[name] = build_query(body, &)
       end
 

--- a/test/plutonium/resource/query_object_test.rb
+++ b/test/plutonium/resource/query_object_test.rb
@@ -262,6 +262,35 @@ module Plutonium
         assert_equal filter, query_object.filter_definitions[:title]
       end
 
+      def test_define_filter_rejects_reserved_control_names
+        Plutonium::Resource::QueryObject::RESERVED_FILTER_NAMES.each do |reserved|
+          error = assert_raises(ArgumentError) do
+            QueryObject.new(MockResource, {}, @request_path) do |qo|
+              qo.define_filter(reserved, ->(scope, value:) { scope })
+            end
+          end
+          assert_match(/reserved/, error.message)
+          assert_match(/q\[#{reserved}\]/, error.message)
+        end
+      end
+
+      def test_define_filter_rejects_reserved_name_given_as_string
+        error = assert_raises(ArgumentError) do
+          QueryObject.new(MockResource, {}, @request_path) do |qo|
+            qo.define_filter("scope", ->(scope, value:) { scope })
+          end
+        end
+        assert_match(/reserved/, error.message)
+      end
+
+      def test_define_filter_allows_non_reserved_names
+        query_object = QueryObject.new(MockResource, {}, @request_path) do |qo|
+          qo.define_filter(:status, ->(scope, value:) { scope.where(status: value) })
+        end
+
+        assert query_object.filter_definitions.key?(:status)
+      end
+
       # ==================== Sorter Definition Tests ====================
 
       def test_define_sorter_with_symbol


### PR DESCRIPTION
## What

Reject defining a resource filter whose name collides with a built-in query control: `search`, `scope`, `sort_fields`, `sort_directions`.

## Why

Filters live under the `q[<name>]` query-string namespace, right alongside the built-in controls the query object parses from the same namespace (`q[search]`, `q[scope]`, `q[sort_fields]`, `q[sort_directions]`). A filter named after one of those collides:

- In the URL, `q[scope]` would mean both "the scope control" (a string) and "the scope filter's inputs" (a hash) — the query string can't carry both.
- In the `FilterForm`, `filter_form_values` strips exactly those four keys from the form's record, and `create_child` memoizes fields by key, so a filter sharing a control name silently shadows (or is shadowed by) the hidden control field.

There was no guard against this — `define_filter` accepted any name. This is a latent footgun independent of any single view; reserving the names closes the whole class at the source.

## How

- Add `RESERVED_FILTER_NAMES = %i[search scope sort_fields sort_directions]` on `QueryObject` (the same four keys `filter_form_values` strips and the query object parses).
- Guard at the single chokepoint, `define_filter`, raising an actionable `ArgumentError` that names the offending key and lists the reserved set. This mirrors the existing reserved-key guards in `form_layout.rb` / `display_layout.rb` ("`section :…` is reserved").

## Scope / safety

- Only **filter** names are reserved. Scope and sort *names* are values (`q[scope]=<name>`, `q[sort_fields][]=<name>`), not keys, so they can't collide — no guard needed there.
- `define_standard_queries` uses `define_search`, not `define_filter`, so no internal caller trips the guard. Grepped `lib` + `test/dummy`: no existing filter uses a reserved name, so nothing breaks — this only rejects new misuse.
- Purely additive hardening; complementary to #145 (which fixes the sort/scope-loss bug). Neither depends on the other.

## Tests

`test/plutonium/resource/query_object_test.rb`: each reserved name raises (symbol and string forms), the error message is actionable, and a normal filter name still works. Full file green (73 tests, 165 assertions).