### PR TITLE
fix(ui): float slim-select dropdown above modal instead of clipping it

### DIFF
--- a/src/js/controllers/slim_select_controller.js
+++ b/src/js/controllers/slim_select_controller.js
@@ -33,28 +33,23 @@ export default class extends Controller {
 
   #setupSlimSelect() {
     const settings = {};
-    const modal = document.querySelector('[data-controller="remote-modal"]');
+    this.modal = document.querySelector('[data-controller="remote-modal"]');
 
-    if (modal) {
-      // Create a dedicated container div right after the select element
-      this.dropdownContainer = document.createElement("div");
-      this.dropdownContainer.className = "ss-dropdown-container";
-
-      // Make the select wrapper position relative to contain the absolute dropdown
-      const selectWrapper = this.element.parentNode;
-      const originalPosition = getComputedStyle(selectWrapper).position;
-      if (originalPosition === "static") {
-        selectWrapper.style.position = "relative";
-        this.modifiedSelectWrapper = selectWrapper;
-      }
-
-      // Insert the container right after the select element
-      this.element.parentNode.insertBefore(
-        this.dropdownContainer,
-        this.element.nextSibling
-      );
-
-      settings.contentLocation = this.dropdownContainer;
+    if (this.modal) {
+      // Inside a <dialog> opened via showModal(), the dialog lives in the
+      // browser's top layer: anything rendered outside it (e.g. on
+      // document.body) paints BEHIND it regardless of z-index, and the
+      // dialog is transform-animated (slide/scale), so position:fixed
+      // descendants are rebased to the dialog's box rather than the
+      // viewport. Rendering the dropdown into the select's own container
+      // (SlimSelect's other default) instead leaves it clipped by the
+      // form section's overflow.
+      //
+      // So attach the dropdown to the dialog itself and position it
+      // absolutely relative to the dialog's box (see #applyModalPositioning).
+      // It then escapes every section's overflow while staying inside the
+      // top layer, on top of the form. Mirrors the flatpickr controller.
+      settings.contentLocation = this.modal;
       settings.contentPosition = "absolute";
       settings.openPosition = "auto";
     }
@@ -73,125 +68,58 @@ export default class extends Controller {
       events: events,
     });
 
-    // Add event listeners for better positioning
-    this.handleDropdownPosition();
-
-    // Bind event handlers for proper cleanup
-    this.boundHandleDropdownOpen = this.handleDropdownOpen.bind(this);
-    this.boundHandleDropdownClose = this.handleDropdownClose.bind(this);
-
-    // Add event listeners to properly handle dropdown visibility
-    this.element.addEventListener("ss:open", this.boundHandleDropdownOpen);
-    this.element.addEventListener("ss:close", this.boundHandleDropdownClose);
-
-    // Add mutation observer to track aria-expanded attribute
-    this.setupAriaObserver();
-  }
-
-  handleDropdownPosition() {
-    if (this.dropdownContainer) {
-      // Reposition dropdown when window resizes or scrolls
-      const repositionDropdown = () => {
-        const selectRect = this.element.getBoundingClientRect();
-
-        // Calculate if there's enough space below
-        const spaceBelow = window.innerHeight - selectRect.bottom;
-        const spaceAbove = selectRect.top;
-
-        if (spaceBelow < 200 && spaceAbove > spaceBelow) {
-          // Position above if not enough space below
-          this.dropdownContainer.style.top = "auto";
-          this.dropdownContainer.style.bottom = "100%";
-          this.dropdownContainer.style.borderRadius = "0.375rem 0.375rem 0 0";
-        } else {
-          // Position below (default)
-          this.dropdownContainer.style.bottom = "auto";
-          this.dropdownContainer.style.borderRadius = "0 0 0.375rem 0.375rem";
-        }
-      };
-
-      // Initial positioning
-      setTimeout(repositionDropdown, 0);
-
-      // Reposition on events
-      window.addEventListener("resize", repositionDropdown);
-      window.addEventListener("scroll", repositionDropdown);
-
-      // Store references for cleanup
-      this.repositionDropdown = repositionDropdown;
+    if (this.modal) {
+      this.#applyModalPositioning();
     }
   }
 
-  handleDropdownOpen() {
-    if (this.dropdownContainer) {
-      // When dropdown opens, ensure our container is properly sized
-      this.dropdownContainer.style.height = "auto";
-      this.dropdownContainer.style.overflow = "visible";
+  // Re-base SlimSelect's dropdown positioning onto the modal's coordinate
+  // system. SlimSelect computes document coordinates (rect + window scroll),
+  // which are wrong for content parented to a transform-animated <dialog>:
+  // an absolutely-positioned child is placed relative to the dialog's box,
+  // not the document. We override the two leaf positioners so SlimSelect
+  // keeps deciding up-vs-down (and its own open/scroll/resize triggers keep
+  // firing), but the actual offsets are measured against the dialog. A
+  // capture-phase scroll listener covers scrolls of the dialog's own
+  // content, which never reach SlimSelect's window-level scroll listener.
+  #applyModalPositioning() {
+    const render = this.slimSelect.render;
+    const openAbove = render.classes.openAbove;
+    const openBelow = render.classes.openBelow;
 
-      // Add open class for better CSS targeting
-      this.dropdownContainer.classList.add("ss-active");
+    const place = (above) => {
+      const mainEl = render.main.main;
+      const content = render.content.main;
+      const mainHeight = mainEl.offsetHeight;
+      const contentHeight = content.offsetHeight;
 
-      // Ensure this dropdown appears above others
-      const allContainers = document.querySelectorAll(".ss-dropdown-container");
-      allContainers.forEach((container) => {
-        if (container !== this.dropdownContainer) {
-          container.style.zIndex = "9999";
-        }
-      });
-      this.dropdownContainer.style.zIndex = "10000";
-    }
-  }
+      mainEl.classList.remove(openAbove, openBelow);
+      content.classList.remove(openAbove, openBelow);
+      mainEl.classList.add(above ? openAbove : openBelow);
+      content.classList.add(above ? openAbove : openBelow);
 
-  handleDropdownClose() {
-    if (this.dropdownContainer) {
-      // Remove active class
-      this.dropdownContainer.classList.remove("ss-active");
-    }
-  }
+      const inputRect = mainEl.getBoundingClientRect();
+      const modalRect = this.modal.getBoundingClientRect();
 
-  setupAriaObserver() {
-    // Track aria-expanded attribute on the select element or its wrapper
-    if (this.element) {
-      this.ariaObserver = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.attributeName === "aria-expanded") {
-            const expanded =
-              mutation.target.getAttribute("aria-expanded") === "true";
-            if (expanded) {
-              this.handleDropdownOpen();
-            } else {
-              this.handleDropdownClose();
-            }
-          }
-        });
-      });
+      content.style.margin = above
+        ? "-" + (mainHeight + contentHeight - 1) + "px 0px 0px 0px"
+        : "-1px 0px 0px 0px";
+      content.style.top =
+        inputRect.top + inputRect.height - modalRect.top + "px";
+      content.style.left = inputRect.left - modalRect.left + "px";
+      content.style.width = inputRect.width + "px";
+    };
 
-      // Look for the actual element that gets the aria-expanded attribute
-      const possibleTargets = [
-        this.element,
-        this.element.parentNode.querySelector(".ss-main"),
-        this.element.parentNode.querySelector("[aria-expanded]"),
-      ];
+    render.moveContentAbove = () => place(true);
+    render.moveContentBelow = () => place(false);
 
-      const target = possibleTargets.find(
-        (el) => el && el.hasAttribute && el.hasAttribute("aria-expanded")
-      );
-
-      if (target) {
-        this.ariaObserver.observe(target, {
-          attributes: true,
-          attributeFilter: ["aria-expanded"],
-        });
-
-        // Check initial state
-        const expanded = target.getAttribute("aria-expanded") === "true";
-        if (expanded) {
-          this.handleDropdownOpen();
-        } else {
-          this.handleDropdownClose();
-        }
+    this.boundModalReposition = () => {
+      if (!this.slimSelect) return;
+      if (this.slimSelect.settings.isOpen || this.slimSelect.settings.isFullOpen) {
+        this.slimSelect.render.moveContent();
       }
-    }
+    };
+    document.addEventListener("scroll", this.boundModalReposition, true);
   }
 
   disconnect() {
@@ -249,50 +177,14 @@ export default class extends Controller {
   }
 
   #cleanupSlimSelect() {
-    // Clean up event listeners
-    if (this.element) {
-      if (this.boundHandleDropdownOpen) {
-        this.element.removeEventListener(
-          "ss:open",
-          this.boundHandleDropdownOpen
-        );
-      }
-      if (this.boundHandleDropdownClose) {
-        this.element.removeEventListener(
-          "ss:close",
-          this.boundHandleDropdownClose
-        );
-      }
-    }
-
-    // Disconnect observer
-    if (this.ariaObserver) {
-      this.ariaObserver.disconnect();
-      this.ariaObserver = null;
+    if (this.boundModalReposition) {
+      document.removeEventListener("scroll", this.boundModalReposition, true);
+      this.boundModalReposition = null;
     }
 
     if (this.slimSelect) {
       this.slimSelect.destroy();
       this.slimSelect = null;
-    }
-
-    // Clean up event listeners
-    if (this.repositionDropdown) {
-      window.removeEventListener("resize", this.repositionDropdown);
-      window.removeEventListener("scroll", this.repositionDropdown);
-      this.repositionDropdown = null;
-    }
-
-    // Clean up the dropdown container if it exists
-    if (this.dropdownContainer && this.dropdownContainer.parentNode) {
-      this.dropdownContainer.parentNode.removeChild(this.dropdownContainer);
-      this.dropdownContainer = null;
-    }
-
-    // Restore original positioning if we modified it
-    if (this.modifiedSelectWrapper) {
-      this.modifiedSelectWrapper.style.position = "";
-      this.modifiedSelectWrapper = null;
     }
   }
 }


### PR DESCRIPTION
## Problem

Inside a `remote-modal` (a native `<dialog>` opened via `showModal()`), the slim-select controller rendered the dropdown into a container placed next to the `<select>`. That container sits inside the form section, whose `overflow` **clips the dropdown** — on a short section the options render inside the section box and are effectively unreachable.

## Why the obvious fixes don't work

- **Attach to `document.body`** — a `<dialog>` opened with `showModal()` lives in the browser's **top layer**; anything rendered outside it paints *behind* it regardless of `z-index`.
- **`position: fixed`** — the slide-over dialog is **transform-animated** (`translate-x-full → translate-x-0`), and a transform ancestor rebases `fixed` descendants to the dialog's box rather than the viewport.

## Fix

Attach the dropdown to the dialog element itself and position it **absolutely against the dialog's rect**, overriding SlimSelect's two leaf positioners (`moveContentAbove`/`moveContentBelow`). SlimSelect still decides up-vs-down and keeps driving its own open/scroll/resize triggers; only the coordinate base changes. A capture-phase `scroll` listener covers scrolls of the dialog's own content, which never reach SlimSelect's window-level listener.

This mirrors the approach the `flatpickr` controller already uses for the same top-layer/transform problem.

Non-modal selects are unchanged (SlimSelect defaults).

## Testing

Open a resource form in a modal (e.g. a kanban card's edit drawer), open a `slim_select` in a short/collapsible section, and confirm the dropdown floats above the form rather than being clipped — both opening downward and, near the viewport bottom, upward.
